### PR TITLE
Add High Sierra legacy build workflow

### DIFF
--- a/.github/workflows/high-sierra-only.yml
+++ b/.github/workflows/high-sierra-only.yml
@@ -33,6 +33,8 @@ jobs:
         env:
           # C'est la ligne magique pour High Sierra
           MACOSX_DEPLOYMENT_TARGET: "10.13"
+          # Active le mode legacy (ES2017) dans vite.config.ts pour Safari 11/13
+          VITE_LEGACY_BUILD: "true"
         run: npm run tauri:build -- --target x86_64-apple-darwin
 
       - name: Renommer et uploader

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "preview": "vite preview",
     "tauri:dev": "tauri dev",
     "tauri:build": "tauri build",
+    "build:legacy": "VITE_LEGACY_BUILD=true npm run tauri:build",
     "tauri:android": "tauri android dev",
     "mobile:android": "tauri android build"
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,6 +9,10 @@ const __dirname = path.dirname(__filename);
 
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, ".", "");
+
+  // Check for legacy build flag
+  const isLegacyBuild = process.env.VITE_LEGACY_BUILD === "true";
+
   return {
     base: "./",
     server: {
@@ -17,7 +21,8 @@ export default defineConfig(({ mode }) => {
       strictPort: true,
     },
     build: {
-      target: "es2022",
+      // Use es2017 for High Sierra compatibility, otherwise es2022
+      target: isLegacyBuild ? "es2017" : "es2022",
     },
     plugins: [react()],
     resolve: {


### PR DESCRIPTION
Implemented a workflow to build the application compatible with macOS High Sierra (10.13.6).

Changes:
1.  **Vite Configuration (`vite.config.ts`)**: Added logic to check for the `VITE_LEGACY_BUILD` environment variable. If set to "true", the build target is lowered to `es2017` (supported by Safari 11 on High Sierra), otherwise it defaults to `es2022`.
2.  **GitHub Workflow (`.github/workflows/high-sierra-only.yml`)**: Updated the existing workflow to define `VITE_LEGACY_BUILD: "true"` during the build step, ensuring the artifact is compatible with older webviews.
3.  **Package Script (`package.json`)**: Added a `"build:legacy"` script (`VITE_LEGACY_BUILD=true npm run tauri:build`) to easily trigger this build mode locally.

This ensures the app can run on the requested legacy platform without compromising modern builds.

---
*PR created automatically by Jules for task [16034650495158739071](https://jules.google.com/task/16034650495158739071) started by @G-kylexy*