### PR TITLE
⚡ Bolt: Move indexedCount calculation to DownloadsView

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense, useEffect, useState, useCallback, useMemo } from "react";
+import React, { Suspense, useEffect, useState, useCallback } from "react";
 import Sidebar from "./components/Sidebar";
 import TopBar from "./components/TopBar";
 import MainView from "./components/MainView";
@@ -92,22 +92,6 @@ const App: React.FC = () => {
     return () => { cancelled = true; };
   }, []);
 
-  const indexedCount = useMemo(() => {
-    if (!syncedData) return 0;
-    let count = 0;
-    const stack = [...syncedData];
-    while (stack.length > 0) {
-      const n = stack.pop();
-      if (n && (n.type === "genre" || n.type === "series")) count++;
-      if (n?.children) {
-        for (const child of n.children) {
-          stack.push(child);
-        }
-      }
-    }
-    return count;
-  }, [syncedData]);
-
   // Persist Synced Data
   useEffect(() => {
     if (!syncedDataHydrated) return;
@@ -159,7 +143,6 @@ const App: React.FC = () => {
               vkTopicId={vkTopicId}
               setVkTopicId={handleSetVkTopicId}
               syncedData={syncedData}
-              indexedCount={indexedCount}
               setSyncedData={setSyncedData}
               hasFullSynced={hasFullSynced}
               setHasFullSynced={setHasFullSynced}

--- a/components/DownloadsView.tsx
+++ b/components/DownloadsView.tsx
@@ -12,7 +12,7 @@ import {
 } from "./Icons";
 import { tauriFs } from "../lib/tauri";
 import { useTranslation, Translations } from "../i18n";
-import { DownloadItem } from "../types";
+import { DownloadItem, VkNode } from "../types";
 import { formatDateISO } from "../utils/formatters";
 import { extractVolumeLabel } from "../utils/text";
 
@@ -22,7 +22,7 @@ interface DownloadsViewProps {
   resumeDownload: (id: string) => void;
   cancelDownload: (id: string) => void;
   retryDownload: (id: string) => void;
-  indexedCount?: number;
+  syncedData: VkNode[] | null;
   downloadPath?: string;
   clearDownloads: () => void;
 }
@@ -243,13 +243,29 @@ const DownloadsView: React.FC<DownloadsViewProps> = ({
   resumeDownload,
   cancelDownload,
   retryDownload,
-  indexedCount = 0,
+  syncedData,
   downloadPath,
   clearDownloads,
 }) => {
   const { t } = useTranslation();
   const [visibleCount, setVisibleCount] = useState(ITEMS_PER_BATCH);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
+
+  const indexedCount = useMemo(() => {
+    if (!syncedData) return 0;
+    let count = 0;
+    const stack = [...syncedData];
+    while (stack.length > 0) {
+      const n = stack.pop();
+      if (n && (n.type === "genre" || n.type === "series")) count++;
+      if (n?.children) {
+        for (const child of n.children) {
+          stack.push(child);
+        }
+      }
+    }
+    return count;
+  }, [syncedData]);
 
   const downloadCounts = useMemo(() => {
     const downloaded = downloads.filter((d) => d.status === "completed").length;

--- a/components/MainView.tsx
+++ b/components/MainView.tsx
@@ -18,7 +18,6 @@ interface MainViewProps {
   vkTopicId: string;
   setVkTopicId: (topicId: string) => void;
   syncedData: VkNode[] | null;
-  indexedCount?: number;
   setSyncedData: (data: VkNode[] | null) => void;
   hasFullSynced: boolean;
   setHasFullSynced: (hasSynced: boolean) => void;
@@ -48,7 +47,6 @@ const MainView: React.FC<MainViewProps> = ({
   vkTopicId,
   setVkTopicId,
   syncedData,
-  indexedCount,
   setSyncedData,
   hasFullSynced,
   setHasFullSynced,
@@ -108,7 +106,7 @@ const MainView: React.FC<MainViewProps> = ({
                   retryDownload={retryDownload}
                   downloadPath={downloadPath}
                   clearDownloads={clearDownloads}
-                  indexedCount={indexedCount}
+                  syncedData={syncedData}
                 />
               );
             case "library":

--- a/package-lock.json
+++ b/package-lock.json
@@ -76,7 +76,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1762,7 +1761,6 @@
       "integrity": "sha512-DZ8VwRFUNzuqJ5khrvwMXHmvPe+zGayJhr2CDNiKB1WBE1ST8Djl00D0IC4vvNmHMdj6DlbYRIaFE7WHjlDl5w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1773,7 +1771,6 @@
       "integrity": "sha512-WPigyYuGhgZ/cTPRXB2EwUw+XvsRA3GqHlsP4qteqrnnjDrApbS7MxcGr/hke5iUoeB7E/gQtrs9I37zAJ0Vjw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1876,7 +1873,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2464,7 +2460,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2491,7 +2486,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -2527,7 +2521,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2628,8 +2621,7 @@
       "version": "4.1.18",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.18.tgz",
       "integrity": "sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tailwindcss-animate": {
       "version": "1.0.7",
@@ -2736,7 +2728,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",


### PR DESCRIPTION
*   💡 **What:** Moved the `indexedCount` calculation from the root `App` component to the lazy-loaded `DownloadsView` component.
*   🎯 **Why:** The calculation traverses the entire `syncedData` tree (which can be large) on every update, blocking the main thread even when the user is not viewing the "Downloads" tab.
*   📊 **Impact:** Prevents unnecessary heavy computation during navigation and data sync when not on the Downloads tab. Reduces the workload of the `App` component.
*   🔬 **Measurement:** `npm run build` passed. The logic is identical but deferred until the component is mounted.


---
*PR created automatically by Jules for task [5486433644170748574](https://jules.google.com/task/5486433644170748574) started by @G-kylexy*