### PR TITLE
⚡ Bolt: Memoize navigation handlers in BrowserView

### DIFF
--- a/components/BrowserView.tsx
+++ b/components/BrowserView.tsx
@@ -514,7 +514,8 @@ const BrowserView: React.FC<BrowserViewProps> = ({
     }
   };
 
-  const navigateTo = async (node: VkNode) => {
+  // Optimization: Memoize navigation handler to prevent re-renders of list items during download progress updates
+  const navigateTo = React.useCallback(async (node: VkNode) => {
     // Pour les fichiers, on lance le téléchargement SANS toucher à la recherche
     if (node.type === "file" && node.url) {
       addDownload(node);
@@ -576,18 +577,18 @@ const BrowserView: React.FC<BrowserViewProps> = ({
     } else {
       setNavPath((prev) => [...prev, node]);
     }
-  };
+  }, [addDownload, isSearching, setSearchQuery, vkToken, syncedData, setSyncedData]);
 
-  const navigateUp = (index?: number) => {
+  const navigateUp = React.useCallback((index?: number) => {
     setNavPath((prev) => {
       if (index === undefined) {
         return prev.slice(0, -1);
       }
       return prev.slice(0, index + 1);
     });
-  };
+  }, []);
 
-  const clearNav = () => setNavPath([]);
+  const clearNav = React.useCallback(() => setNavPath([]), []);
 
   const MAX_BREADCRUMBS = 4;
   const breadcrumbs: {


### PR DESCRIPTION
⚡ **Bolt Performance Optimization**

**What:**
Wrapped `navigateTo`, `navigateUp`, and `clearNav` handlers in `React.useCallback`.

**Why:**
`BrowserView` re-renders frequently (throttled) during file downloads due to updates in the `downloads` prop.
Previously, this caused navigation handlers to be recreated on every render, which in turn caused all `BrowserFolderItem` and `BrowserFileItem` components to re-render, despite being memoized with `React.memo`.
By memoizing these handlers, `React.memo` on the child components can now effectively prevent re-renders for items that are not changing.

**Impact:**
- Reduces re-renders of the file/folder list during active downloads.
- Improves UI responsiveness and reduces CPU usage during downloads.

**Verification:**
- `tsc --noEmit` passes.
- Verified dependencies for `useCallback` are correct.

---
*PR created automatically by Jules for task [17795627937869388535](https://jules.google.com/task/17795627937869388535) started by @G-kylexy*