### PR TITLE
⚡ Bolt: Optimize download progress updates to prevent re-renders

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-05-15 - [Global State Optimization]
+**Learning:** Frequent updates in a root-level hook (`useDownloads`) trigger re-renders of the entire application (`App` -> `MainView` -> `BrowserView`).
+**Action:** When updating state based on frequent events (like progress bars), always check if the *rounded/visible* values have actually changed before creating a new state object reference. This prevents thousands of unnecessary re-renders.


### PR DESCRIPTION
💡 What: Optimized `setDownloads` in `useDownloads` hook to avoid state updates when values (rounded progress, speed, status) haven't changed.
🎯 Why: Download progress events are frequent (every ~200ms per download) but often result in the same rounded progress or status. This caused unnecessary re-renders of the entire `App` component tree, including heavy views like `BrowserView`.
📊 Impact: Reduces re-renders significantly during active downloads, improving UI responsiveness and reducing CPU usage.
🔬 Measurement: Verified logic by ensuring state updates are skipped when new values are strictly equal to current values. Validated with `tsc` and `build`.

---
*PR created automatically by Jules for task [16029685345691494759](https://jules.google.com/task/16029685345691494759) started by @G-kylexy*