### PR TITLE
⚡ Bolt: Prevent BrowserView unmounting to preserve cache and scroll

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-02-19 - Unintentional Component Unmounting
+**Learning:** Comments in `MainView.tsx` claimed `BrowserView` was "ALWAYS mounted" to preserve state, but the `if/else` logic actually unmounted it when inactive. This defeated the purpose of `searchIndex` caching (via `useRef`) and scroll preservation.
+**Action:** Always verify if render logic matches the intended behavior described in comments, especially for conditional rendering intended to hide/show components.

--- a/components/MainView.tsx
+++ b/components/MainView.tsx
@@ -124,39 +124,35 @@ const MainView: React.FC<MainViewProps> = ({
     );
   };
 
-  if (activeTab === "home") {
-    return (
-      <>
-        {/* BrowserView est TOUJOURS monté pour préserver le navPath */}
-        <div style={{ display: activeTab === "home" ? "contents" : "none" }}>
-          <BrowserView
-            vkToken={vkToken}
-            vkGroupId={vkGroupId}
-            vkTopicId={vkTopicId}
-            syncedData={syncedData}
-            setSyncedData={setSyncedData}
-            hasFullSynced={hasFullSynced}
-            setHasFullSynced={setHasFullSynced}
-            searchQuery={searchQuery}
-            setSearchQuery={setSearchQuery}
-            onVkStatusChange={onVkStatusChange}
-            addDownload={addDownload}
-            downloads={downloads}
-            pauseDownload={pauseDownload}
-            resumeDownload={resumeDownload}
-            cancelDownload={cancelDownload}
-            retryDownload={retryDownload}
-            navPath={navPath}
-            setNavPath={setNavPath}
-          />
-        </div>
-        {/* Les autres vues sont rendues normalement */}
-        {activeTab !== "home" && renderSecondaryContent()}
-      </>
-    );
-  }
-
-  return renderSecondaryContent();
+  return (
+    <>
+      {/* BrowserView est TOUJOURS monté pour préserver le navPath, le cache de recherche et la position de scroll */}
+      <div style={{ display: activeTab === "home" ? "contents" : "none" }}>
+        <BrowserView
+          vkToken={vkToken}
+          vkGroupId={vkGroupId}
+          vkTopicId={vkTopicId}
+          syncedData={syncedData}
+          setSyncedData={setSyncedData}
+          hasFullSynced={hasFullSynced}
+          setHasFullSynced={setHasFullSynced}
+          searchQuery={searchQuery}
+          setSearchQuery={setSearchQuery}
+          onVkStatusChange={onVkStatusChange}
+          addDownload={addDownload}
+          downloads={downloads}
+          pauseDownload={pauseDownload}
+          resumeDownload={resumeDownload}
+          cancelDownload={cancelDownload}
+          retryDownload={retryDownload}
+          navPath={navPath}
+          setNavPath={setNavPath}
+        />
+      </div>
+      {/* Les autres vues sont rendues normalement */}
+      {activeTab !== "home" && renderSecondaryContent()}
+    </>
+  );
 };
 
 export default React.memo(MainView);


### PR DESCRIPTION
💡 **What:** Modified `MainView.tsx` to keep the `BrowserView` component mounted at all times, using `display: none` to hide it when inactive, instead of conditionally rendering it.

🎯 **Why:** The previous implementation unintentionally unmounted `BrowserView` when switching tabs, despite comments claiming it was "ALWAYS mounted". This caused:
1. Loss of search index cache (which is stored in a `useRef` inside `BrowserView`), leading to expensive rebuilds of the index upon returning.
2. Loss of scroll position in the main library view.

📊 **Impact:**
- **Instant** tab switching back to the Home/Library view.
- **Preserved** scroll position, improving UX.
- **Eliminated** CPU cost of rebuilding the search index when navigating back to Home.

🔬 **Measurement:**
- Verified via Playwright script that `BrowserView` content exists in the DOM (hidden) when navigating to Settings.
- Visual verification of "Paramètres" page rendering correctly.

---
*PR created automatically by Jules for task [417495041078740843](https://jules.google.com/task/417495041078740843) started by @G-kylexy*