### PR TITLE
reference alternative series title

### DIFF
--- a/src-tauri/src/vk_parser.rs
+++ b/src-tauri/src/vk_parser.rs
@@ -229,9 +229,9 @@ pub fn parse_topic_body(text: &str, exclude_topic_id: Option<&str>) -> Vec<VkNod
                 None => format!("topic_{}", topic_id),
             };
 
-            if seen_ids.contains(&unique_id) {
+            /*if seen_ids.contains(&unique_id) {
                 continue;
-            }
+            }*/
 
             // Find URL position in line for title extraction
             let url_match = caps.get(0).unwrap();
@@ -272,24 +272,28 @@ pub fn parse_topic_body(text: &str, exclude_topic_id: Option<&str>) -> Vec<VkNod
             }
 
             if title.len() < 200 {
-                seen_ids.insert(unique_id.clone());
-                nodes.push(VkNode {
-                    id: unique_id,
-                    title,
-                    node_type: "genre".to_string(),
-                    url: Some(format!("https://vk.com/topic-{}_{}", group_id, topic_id)),
-                    vk_group_id: Some(group_id.to_string()),
-                    vk_topic_id: Some(topic_id.to_string()),
-                    children: Some(Vec::new()),
-                    is_loaded: Some(false),
-                    count: None,
-                    extension: None,
-                    structure_only: None,
-                    vk_owner_id: None,
-                    vk_doc_id: None,
-                    vk_access_key: None,
-                    size_bytes: None,
-                });
+                if let Some(existing) = nodes.iter_mut().find(|n| n.id == unique_id) {
+                    existing.title = format!("{} / {}", existing.title, title);
+                } else {
+                    seen_ids.insert(unique_id.clone());
+                    nodes.push(VkNode {
+                        id: unique_id,
+                        title,
+                        node_type: "genre".to_string(),
+                        url: Some(format!("https://vk.com/topic-{}_{}", group_id, topic_id)),
+                        vk_group_id: Some(group_id.to_string()),
+                        vk_topic_id: Some(topic_id.to_string()),
+                        children: Some(Vec::new()),
+                        is_loaded: Some(false),
+                        count: None,
+                        extension: None,
+                        structure_only: None,
+                        vk_owner_id: None,
+                        vk_doc_id: None,
+                        vk_access_key: None,
+                        size_bytes: None,
+                    });
+                }
             }
         }
 


### PR DESCRIPTION
si on cherche par exemple 'famille Blaireau', dans la version actuelle on ne trouve rien. Pourtant il devrait bien y avoir un résultat. C'est du au fait que le code skip les séries différentes si elles sont sur un même topic. 

Le code actuel concatene les titres des séries du même topic sur le node précédemment créé.

avec ce nouveau code si on fait la même recherche on obtiendra bien un résultat.

Note: je pensais que l'ensemble des titres alternatifs allaient apparaitre mais ce n'est pas le cas. La recherche fonctionnant correctement je n'ai pas cherche plus loin pour que l'affichage soit correct. Le code peut être amélioré sur ce point