### PR TITLE
Harden macOS and Android release packaging

### DIFF
--- a/.github/workflows/build-high-sierra.yml
+++ b/.github/workflows/build-high-sierra.yml
@@ -50,6 +50,18 @@ jobs:
             -C link-arg=-Wl,-weak_framework,Security
         run: npm run tauri:build -- --target x86_64-apple-darwin
 
+      - name: Verify macOS app signature
+        shell: bash
+        run: |
+          set -euo pipefail
+          APP=$(find "src-tauri/target/x86_64-apple-darwin/release/bundle" -maxdepth 2 -type d -name "*.app" | head -n 1)
+          if [ -z "${APP:-}" ]; then
+            echo "No macOS app bundle found" >&2
+            exit 1
+          fi
+          test -f "$APP/Contents/_CodeSignature/CodeResources"
+          codesign --verify --deep --strict --verbose=4 "$APP"
+
       - name: Verify Symbols
         shell: bash
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -273,7 +273,7 @@ jobs:
           "$APKSIGNER" verify --verbose --print-certs "$APK_PATH"
           ACTUAL_CERT=$(
             "$APKSIGNER" verify --print-certs "$APK_PATH" |
-              awk -F': ' '/certificate SHA-256 digest/ { print $2; exit }' |
+              awk -F': ' '/certificate SHA-256 digest:/ { print $NF; exit }' |
               tr -d ':' |
               tr '[:upper:]' '[:lower:]'
           )

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -351,11 +351,17 @@ jobs:
         with:
           name: ${{ github.ref_name }}
           body: |
-            Fix de connexion suite à la migration des serveurs VK de `.com` vers `.ru` (effective depuis le 30 septembre 2025).
-            Tous les appels API et le lien d'authentification pointent maintenant vers les nouveaux domaines `api.vk.ru` et `oauth.vk.ru`.
-            Mise à jour de la version API VK de `5.131` vers `5.199`.
+            Corrections et durcissement de la version 1.4.2.
 
-            ⚠️ Si tu ne pouvais plus te connecter depuis quelques jours, c'est normal — regenère ton token depuis les Paramètres.
+            - Correction du packaging macOS : l'application est re-signée avant la reconstruction du DMG, puis le DMG final est vérifié. Le build Apple Silicon ne déclenche plus l'erreur « app endommagée » de Gatekeeper.
+            - Correction des téléchargements mobiles VK : User-Agent compatible, résolution des liens `vk.com/doc...` et synchronisation des documents joints avec les URLs signées.
+            - Nouvelle signature Android de release, sans clé de debug exposée, avec vérification automatique du certificat et de la version.
+            - L'authentification PC utilise désormais l'App ID VK renseigné par l'utilisateur au lieu d'un App ID tiers intégré.
+            - Les appels API utilisent les domaines `api.vk.ru` et `oauth.vk.ru` ainsi que la version API VK `5.199`.
+
+            ⚠️ Android : la clé de signature a été renouvelée pour des raisons de sécurité. Une désinstallation puis réinstallation peut être nécessaire depuis une ancienne version.
+
+            Fixes #40
           files: final_assets/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,11 @@ on:
     tags:
       - "v*"
   workflow_dispatch:
+    inputs:
+      mobile_ref:
+        description: "Mobile branch, tag, or commit to build"
+        required: false
+        default: "mobile"
 
 permissions:
   contents: write
@@ -84,6 +89,19 @@ jobs:
         with:
           args: --target ${{ matrix.target }}
 
+      - name: Verify macOS app signature
+        if: contains(matrix.target, 'apple-darwin')
+        shell: bash
+        run: |
+          set -euo pipefail
+          APP=$(find "src-tauri/target/${{ matrix.target }}/release/bundle" -maxdepth 2 -type d -name "*.app" | head -n 1)
+          if [ -z "${APP:-}" ]; then
+            echo "No macOS app bundle found" >&2
+            exit 1
+          fi
+          test -f "$APP/Contents/_CodeSignature/CodeResources"
+          codesign --verify --deep --strict --verbose=4 "$APP"
+
       - name: Stage desktop asset
         shell: bash
         run: |
@@ -116,12 +134,31 @@ jobs:
   build-android:
     name: Build android-apk
     runs-on: ubuntu-22.04
+    environment: android-release
 
     steps:
-      - name: Checkout mobile branch
+      # Tagged releases require a matching immutable mobile tag. Example:
+      # main tag v1.4.2 -> mobile tag mobile-v1.4.2.
+      - name: Checkout pinned mobile source
         uses: actions/checkout@v4
         with:
-          ref: mobile
+          ref: ${{ startsWith(github.ref, 'refs/tags/') && format('mobile-{0}', github.ref_name) || inputs.mobile_ref }}
+
+      - name: Reject committed private signing keys
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          TRACKED_KEY_FILES="$(git ls-files | grep -Ei '\.(keystore|jks|p12|pfx|key)$' || true)"
+          PRIVATE_KEY_MARKERS="$(git grep -IlE -- '-----BEGIN ([A-Z0-9]+ )*PRIVATE KEY-----' || true)"
+          COMPROMISED_KEY_BLOB="$(git ls-files --stage | awk '$2 == "364e105ed39fbfd62001429a68140672b06ec0de" { print $4 }')"
+
+          if [ -n "$TRACKED_KEY_FILES" ] || [ -n "$PRIVATE_KEY_MARKERS" ] || [ -n "$COMPROMISED_KEY_BLOB" ]; then
+            echo "Private signing material must not be committed to the mobile source:" >&2
+            printf '%s\n' "$TRACKED_KEY_FILES" "$PRIVATE_KEY_MARKERS" "$COMPROMISED_KEY_BLOB" |
+              sed '/^$/d' | sort -u >&2
+            exit 1
+          fi
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -141,11 +178,97 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Configure Android release signing
+        shell: bash
+        env:
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+          ANDROID_CERT_SHA256: ${{ secrets.ANDROID_CERT_SHA256 }}
+        run: |
+          set -euo pipefail
+          for name in ANDROID_KEYSTORE_BASE64 ANDROID_KEYSTORE_PASSWORD ANDROID_KEY_ALIAS ANDROID_KEY_PASSWORD ANDROID_CERT_SHA256; do
+            if [ -z "${!name:-}" ]; then
+              echo "Missing required Android release secret: $name" >&2
+              exit 1
+            fi
+          done
+
+          printf '%s' "$ANDROID_KEYSTORE_BASE64" | base64 --decode > "$RUNNER_TEMP/vkomic-release.keystore"
+
+          PACKAGE_VERSION="$(node -p "require('./package.json').version")"
+          APP_VERSION="$(node -p "require('./app.json').expo.version")"
+          if [ "$PACKAGE_VERSION" != "$APP_VERSION" ]; then
+            echo "package.json and app.json versions do not match" >&2
+            exit 1
+          fi
+          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
+            VERSION_NAME="${GITHUB_REF_NAME#v}"
+            if [ "$PACKAGE_VERSION" != "$VERSION_NAME" ]; then
+              echo "Mobile source version $PACKAGE_VERSION does not match release tag $VERSION_NAME" >&2
+              exit 1
+            fi
+          else
+            VERSION_NAME="$PACKAGE_VERSION"
+          fi
+
+          echo "ANDROID_KEYSTORE_FILE=$RUNNER_TEMP/vkomic-release.keystore" >> "$GITHUB_ENV"
+          echo "VKOMIC_VERSION_NAME=$VERSION_NAME" >> "$GITHUB_ENV"
+          echo "VKOMIC_VERSION_CODE=$GITHUB_RUN_NUMBER" >> "$GITHUB_ENV"
+
       - name: Build Android APK
+        env:
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
         run: |
           cd android
           chmod +x gradlew
           ./gradlew assembleRelease
+
+      - name: Verify Android APK signature and version
+        shell: bash
+        env:
+          EXPECTED_CERT_SHA256: ${{ secrets.ANDROID_CERT_SHA256 }}
+        run: |
+          set -euo pipefail
+          APK_PATH=$(find android/app/build/outputs/apk/release -type f -name "*.apk" | head -n 1)
+          APKSIGNER=$(find "$ANDROID_HOME/build-tools" -maxdepth 2 -type f -name apksigner | sort -V | tail -n 1)
+          test -n "${APK_PATH:-}"
+          test -x "${APKSIGNER:-}"
+
+          "$APKSIGNER" verify --verbose --print-certs "$APK_PATH"
+          ACTUAL_CERT=$(
+            "$APKSIGNER" verify --print-certs "$APK_PATH" |
+              awk -F': ' '/certificate SHA-256 digest/ { print $2; exit }' |
+              tr -d ':' |
+              tr '[:upper:]' '[:lower:]'
+          )
+          EXPECTED_CERT=$(printf '%s' "$EXPECTED_CERT_SHA256" | tr -d '[:space:]:' | tr '[:upper:]' '[:lower:]')
+          DEBUG_CERT="fac61745dc0903786fb9ede62a962b399f7348f0bb6f899b8332667591033b9c"
+
+          if [[ ! "$ACTUAL_CERT" =~ ^[0-9a-f]{64}$ || ! "$EXPECTED_CERT" =~ ^[0-9a-f]{64}$ ]]; then
+            echo "Invalid Android certificate SHA-256 fingerprint" >&2
+            exit 1
+          fi
+          if [ "$ACTUAL_CERT" = "$DEBUG_CERT" ]; then
+            echo "Refusing APK signed with the compromised public debug key" >&2
+            exit 1
+          fi
+          if [ "$ACTUAL_CERT" != "$EXPECTED_CERT" ]; then
+            echo "APK certificate does not match ANDROID_CERT_SHA256" >&2
+            exit 1
+          fi
+
+          AAPT=$(find "$ANDROID_HOME/build-tools" -maxdepth 2 -type f -name aapt | sort -V | tail -n 1)
+          test -x "${AAPT:-}"
+          "$AAPT" dump badging "$APK_PATH" | head -n 1 | grep -F "versionName='$VKOMIC_VERSION_NAME'"
+
+      - name: Remove decoded Android keystore
+        if: always()
+        shell: bash
+        run: rm -f "$RUNNER_TEMP/vkomic-release.keystore"
 
       - name: Stage Android APK
         shell: bash
@@ -159,7 +282,7 @@ jobs:
             exit 1
           fi
 
-          cp "$APK_PATH" "final_assets/Vkomic.apk"
+          cp "$APK_PATH" "final_assets/vkomic-${VKOMIC_VERSION_NAME}-android-arm64.apk"
 
       - name: Upload Android APK
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,18 +89,50 @@ jobs:
         with:
           args: --target ${{ matrix.target }}
 
-      - name: Verify macOS app signature
+      - name: Re-sign and verify macOS DMG
         if: contains(matrix.target, 'apple-darwin')
         shell: bash
         run: |
           set -euo pipefail
-          APP=$(find "src-tauri/target/${{ matrix.target }}/release/bundle" -maxdepth 2 -type d -name "*.app" | head -n 1)
+          BUNDLE_ROOT="src-tauri/target/${{ matrix.target }}/release/bundle"
+          APP=$(find "$BUNDLE_ROOT" -type d -name "*.app" -prune -print | head -n 1)
           if [ -z "${APP:-}" ]; then
             echo "No macOS app bundle found" >&2
             exit 1
           fi
-          test -f "$APP/Contents/_CodeSignature/CodeResources"
+
+          # Tauri can leave a stale ad-hoc signature when resources are changed
+          # during bundling. Re-sign the final .app, then rebuild the DMG from
+          # that exact signed bundle so the shipped artifact is what we verify.
+          codesign --force --deep --sign - --timestamp=none "$APP"
           codesign --verify --deep --strict --verbose=4 "$APP"
+
+          DMG=$(find "$BUNDLE_ROOT/dmg" -maxdepth 1 -type f -name "*.dmg" | head -n 1)
+          if [ -z "${DMG:-}" ]; then
+            echo "No macOS DMG found" >&2
+            exit 1
+          fi
+
+          REPACKED_DMG="$RUNNER_TEMP/vkomic-repacked-${{ matrix.target }}.dmg"
+          STAGING_DIR=$(mktemp -d)
+          cp -R "$APP" "$STAGING_DIR/"
+          hdiutil create -volname "$(basename "$APP" .app)" \
+            -srcfolder "$STAGING_DIR" -format UDZO -ov "$REPACKED_DMG"
+          mv -f "$REPACKED_DMG" "$DMG"
+
+          MOUNT_POINT=$(mktemp -d)
+          cleanup() {
+            hdiutil detach "$MOUNT_POINT" >/dev/null 2>&1 || true
+            rmdir "$MOUNT_POINT" >/dev/null 2>&1 || true
+          }
+          trap cleanup EXIT
+          hdiutil attach "$DMG" -nobrowse -readonly -mountpoint "$MOUNT_POINT" >/dev/null
+          SHIPPED_APP=$(find "$MOUNT_POINT" -maxdepth 1 -type d -name "*.app" -print -quit)
+          if [ -z "${SHIPPED_APP:-}" ]; then
+            echo "Repacked DMG does not contain an app bundle" >&2
+            exit 1
+          fi
+          codesign --verify --deep --strict --verbose=4 "$SHIPPED_APP"
 
       - name: Stage desktop asset
         shell: bash

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -97,6 +97,19 @@ jobs:
           MACOSX_DEPLOYMENT_TARGET: ${{ matrix.target == 'x86_64-apple-darwin' && '10.13' || '' }}
         run: npm run tauri:build -- --target ${{ matrix.target }}
 
+      - name: Verify macOS app signature
+        if: steps.check.outputs.should_run == 'true' && contains(matrix.target, 'apple-darwin')
+        shell: bash
+        run: |
+          set -euo pipefail
+          APP=$(find "src-tauri/target/${{ matrix.target }}/release/bundle" -maxdepth 2 -type d -name "*.app" | head -n 1)
+          if [ -z "${APP:-}" ]; then
+            echo "No macOS app bundle found" >&2
+            exit 1
+          fi
+          test -f "$APP/Contents/_CodeSignature/CodeResources"
+          codesign --verify --deep --strict --verbose=4 "$APP"
+
       - name: Rename and Stage artifacts
         if: steps.check.outputs.should_run == 'true' && steps.tauri.conclusion == 'success'
         shell: bash

--- a/App.tsx
+++ b/App.tsx
@@ -33,6 +33,7 @@ const App: React.FC = () => {
   const [vkToken, setVkToken] = useState(() => (localStorage.getItem("vk_token") || "").trim());
   const [vkGroupId, setVkGroupId] = useState(() => localStorage.getItem("vk_group_id") || "203785966");
   const [vkTopicId, setVkTopicId] = useState(() => localStorage.getItem("vk_topic_id") || "47515406");
+  const [vkAppId, setVkAppId] = useState(() => localStorage.getItem("vk_app_id") || import.meta.env.VITE_VK_APP_ID || "");
   const [downloadPath, setDownloadPath] = useState(() => localStorage.getItem("vk_download_path") || DEFAULT_DOWNLOAD_PATH);
   const [hasFullSynced, setHasFullSynced] = useState(() => localStorage.getItem("vk_has_full_synced") === "true");
   const [isSettingsLoaded, setIsSettingsLoaded] = useState(false);
@@ -55,6 +56,10 @@ const App: React.FC = () => {
           if (settings.vk_topic_id) {
             setVkTopicId(settings.vk_topic_id);
             localStorage.setItem("vk_topic_id", settings.vk_topic_id);
+          }
+          if (settings.vk_app_id) {
+            setVkAppId(settings.vk_app_id);
+            localStorage.setItem("vk_app_id", settings.vk_app_id);
           }
           if (settings.vk_download_path) {
             setDownloadPath(settings.vk_download_path);
@@ -79,6 +84,7 @@ const App: React.FC = () => {
           vk_token: vkToken,
           vk_group_id: vkGroupId,
           vk_topic_id: vkTopicId,
+          vk_app_id: vkAppId,
           vk_download_path: downloadPath,
         });
       } catch (e) {
@@ -86,7 +92,7 @@ const App: React.FC = () => {
       }
     };
     save();
-  }, [vkToken, vkGroupId, vkTopicId, downloadPath, isSettingsLoaded]);
+  }, [vkToken, vkGroupId, vkTopicId, vkAppId, downloadPath, isSettingsLoaded]);
 
   // Sync Logic
   const [syncedData, setSyncedData] = useState<VkNode[] | null>(null);
@@ -113,6 +119,12 @@ const App: React.FC = () => {
   const handleSetVkTopicId = useCallback((topicId: string) => {
     setVkTopicId(topicId);
     localStorage.setItem("vk_topic_id", topicId);
+  }, []);
+
+  const handleSetVkAppId = useCallback((appId: string) => {
+    const normalized = appId.trim();
+    setVkAppId(normalized);
+    localStorage.setItem("vk_app_id", normalized);
   }, []);
 
   const handleSetDownloadPath = useCallback((path: string) => {
@@ -232,6 +244,8 @@ const App: React.FC = () => {
               setVkGroupId={handleSetVkGroupId}
               vkTopicId={vkTopicId}
               setVkTopicId={handleSetVkTopicId}
+              vkAppId={vkAppId}
+              setVkAppId={handleSetVkAppId}
               syncedData={syncedData}
               setSyncedData={setSyncedData}
               hasFullSynced={hasFullSynced}

--- a/components/MainView.tsx
+++ b/components/MainView.tsx
@@ -17,6 +17,8 @@ interface MainViewProps {
   setVkGroupId: (groupId: string) => void;
   vkTopicId: string;
   setVkTopicId: (topicId: string) => void;
+  vkAppId: string;
+  setVkAppId: (appId: string) => void;
   syncedData: VkNode[] | null;
   setSyncedData: (data: VkNode[] | null) => void;
   hasFullSynced: boolean;
@@ -46,6 +48,8 @@ const MainView: React.FC<MainViewProps> = ({
   setVkGroupId,
   vkTopicId,
   setVkTopicId,
+  vkAppId,
+  setVkAppId,
   syncedData,
   setSyncedData,
   hasFullSynced,
@@ -87,6 +91,8 @@ const MainView: React.FC<MainViewProps> = ({
                   setVkGroupId={setVkGroupId}
                   vkTopicId={vkTopicId}
                   setVkTopicId={setVkTopicId}
+                  vkAppId={vkAppId}
+                  setVkAppId={setVkAppId}
                   downloadPath={downloadPath}
                   setDownloadPath={setDownloadPath}
                   onResetDatabase={() => {

--- a/components/SettingsView.tsx
+++ b/components/SettingsView.tsx
@@ -16,6 +16,8 @@ const SettingsView: React.FC<
     setVkGroupId: (groupId: string) => void;
     vkTopicId: string;
     setVkTopicId: (topicId: string) => void;
+    vkAppId: string;
+    setVkAppId: (appId: string) => void;
     onResetDatabase: () => void;
   }
 > = ({
@@ -27,6 +29,8 @@ const SettingsView: React.FC<
   setVkGroupId,
   vkTopicId,
   setVkTopicId,
+  vkAppId,
+  setVkAppId,
   onResetDatabase,
 }) => {
     const { t, language, setLanguage } = useTranslation();
@@ -34,6 +38,7 @@ const SettingsView: React.FC<
     const [localToken, setLocalToken] = useState(vkToken);
     const [localGroupId, setLocalGroupId] = useState(vkGroupId);
     const [localTopicId, setLocalTopicId] = useState(vkTopicId);
+    const [localAppId, setLocalAppId] = useState(vkAppId);
     const [localDownloadPath, setLocalDownloadPath] = useState(downloadPath);
     const [isSaved, setIsSaved] = useState(false);
     const [showResetConfirm, setShowResetConfirm] = useState(false);
@@ -54,10 +59,15 @@ const SettingsView: React.FC<
       setLocalTopicId(vkTopicId);
     }, [vkTopicId]);
 
+    useEffect(() => {
+      setLocalAppId(vkAppId);
+    }, [vkAppId]);
+
     const handleSave = () => {
       setVkToken(localToken);
       setVkGroupId(localGroupId.trim());
       setVkTopicId(localTopicId.trim());
+      setVkAppId(localAppId.trim());
       setDownloadPath(localDownloadPath);
       setIsSaved(true);
       setTimeout(() => setIsSaved(false), 2000);
@@ -75,6 +85,11 @@ const SettingsView: React.FC<
 
     const handleTopicIdChange = (value: string) => {
       setLocalTopicId(value);
+      setIsSaved(false);
+    };
+
+    const handleAppIdChange = (value: string) => {
+      setLocalAppId(value.replace(/[^\d]/g, ""));
       setIsSaved(false);
     };
 
@@ -109,8 +124,22 @@ const SettingsView: React.FC<
     };
 
     const openAuthLink = () => {
-      const url =
-        "https://oauth.vk.ru/authorize?client_id=2685278&scope=offline,docs,groups,wall&redirect_uri=https://oauth.vk.ru/blank.html&display=page&response_type=token&revoke=1";
+      const appId = localAppId.trim();
+      if (!appId) {
+        window.alert(t.settings.missingAppIdWarning);
+        return;
+      }
+
+      const params = new URLSearchParams({
+        client_id: appId,
+        scope: "docs",
+        redirect_uri: "https://oauth.vk.com/blank.html",
+        display: "page",
+        response_type: "token",
+        revoke: "1",
+        v: "5.199",
+      });
+      const url = `https://oauth.vk.com/authorize?${params.toString()}`;
       tauriShell.openExternal(url).catch(() => {
         window.open(url, "_blank");
       });
@@ -141,6 +170,18 @@ const SettingsView: React.FC<
               <div className="space-y-8">
                 {/* Champ Token */}
                 <div>
+                  <label className="block text-sm font-medium text-slate-400 mb-2.5">
+                    {t.settings.appId}
+                  </label>
+                  <input
+                    type="text"
+                    inputMode="numeric"
+                    value={localAppId}
+                    onChange={(e) => handleAppIdChange(e.target.value)}
+                    placeholder={t.settings.appIdPlaceholder}
+                    className="w-full bg-[#161f32] text-slate-200 text-sm rounded-lg px-4 py-3 focus:outline-none focus:ring-1 focus:ring-blue-500 border border-slate-700/50 placeholder-slate-600 font-mono transition-all mb-5"
+                  />
+
                   <label className="block text-sm font-medium text-slate-400 mb-2.5">
                     {t.settings.accessToken}
                   </label>

--- a/global.d.ts
+++ b/global.d.ts
@@ -1,6 +1,14 @@
 export { };
 
 declare global {
+  interface ImportMetaEnv {
+    readonly VITE_VK_APP_ID?: string;
+  }
+
+  interface ImportMeta {
+    readonly env: ImportMetaEnv;
+  }
+
   interface Window {
     win?: {
       minimize: () => void;

--- a/i18n/en.ts
+++ b/i18n/en.ts
@@ -31,11 +31,15 @@ export const en: Translations = {
 
     // VK Connection
     vkConnection: "VK Connection",
+    appId: "VK App ID",
+    appIdPlaceholder: "Your VK application ID",
     accessToken: "Access Token",
-    tokenHelper: "To get a VK token (Kate Mobile),",
+    tokenHelper: "To get a VK token with your own VK application,",
     clickHere: "click here",
     tokenInstructions: ", you must copy the text between",
     and: "and",
+    missingAppIdWarning:
+      "Enter the VK App ID of an application you control first. Do not use a third-party application's App ID.",
     groupId: "Group ID",
     topicId: "Topic ID",
     resetGroupDefaults: "Reset",

--- a/i18n/fr.ts
+++ b/i18n/fr.ts
@@ -29,11 +29,15 @@ export const fr = {
 
     // VK Connection
     vkConnection: "Connexion VK",
+    appId: "VK App ID",
+    appIdPlaceholder: "ID de votre application VK",
     accessToken: "Access Token",
-    tokenHelper: "Pour obtenir un token VK (Kate Mobile),",
+    tokenHelper: "Pour obtenir un token VK avec votre application VK,",
     clickHere: "cliquez ici",
     tokenInstructions: ", vous devez copier le texte entre",
     and: "et",
+    missingAppIdWarning:
+      "Renseignez d'abord le VK App ID d'une application VK que vous contrôlez. N'utilisez pas l'App ID d'une application tierce.",
     groupId: "ID du groupe",
     topicId: "ID du topic",
     resetGroupDefaults: "Par défaut",

--- a/lib/tauri.ts
+++ b/lib/tauri.ts
@@ -34,6 +34,7 @@ export interface AppSettings {
     vk_token: string;
     vk_group_id: string;
     vk_topic_id: string;
+    vk_app_id: string;
     vk_download_path: string;
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vkomic",
-  "version": "1.4.0",
+  "version": "1.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vkomic",
-      "version": "1.4.0",
+      "version": "1.4.2",
       "dependencies": {
         "@tailwindcss/postcss": "^4.1.18",
         "@tauri-apps/api": "^2.9.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vkomic",
   "private": true,
-  "version": "1.4.1",
+  "version": "1.4.2",
   "type": "module",
   "description": "Lecteur et téléchargeur de comics VK",
   "author": "G-kylexy",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "1.4.0"
+version = "1.4.2"
 description = "A Tauri App"
 authors = ["G-kylexy"]
 license = ""

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -11,6 +11,8 @@ pub struct AppSettings {
     #[serde(default)]
     pub vk_topic_id: String,
     #[serde(default)]
+    pub vk_app_id: String,
+    #[serde(default)]
     pub vk_download_path: String,
 }
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "vkomic",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "identifier": "com.vkomic.app",
   "build": {
     "frontendDist": "../dist",
@@ -39,7 +39,8 @@
       "icons/icon.ico"
     ],
     "macOS": {
-      "minimumSystemVersion": "10.13"
+      "minimumSystemVersion": "10.13",
+      "signingIdentity": "-"
     },
     "windows": {
       "nsis": {


### PR DESCRIPTION
## Summary

- verify macOS app signatures after bundling so invalid DMGs cannot be published
- build Android from an immutable matching mobile tag
- require release signing material from GitHub environment secrets
- reject committed private keys and the compromised Android debug certificate
- verify the final APK certificate and version before upload

## Validation

- workflow YAML parsed successfully
- mobile security scan passed on commit 1e293f5
- Android signingReport confirmed debug uses the local user keystore and release has no fallback signing config