### PR TITLE
release: prepare mobile 1.4.2

### DIFF
--- a/app.json
+++ b/app.json
@@ -16,14 +16,14 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.anonymous.vkomicmobile",
-      "buildNumber": "2"
+      "buildNumber": "3"
     },
     "android": {
       "adaptiveIcon": {
         "foregroundImage": "./assets/adaptive-icon.png",
         "backgroundColor": "#0B1222"
       },
-      "versionCode": 2,
+      "versionCode": 3,
       "edgeToEdgeEnabled": true,
       "predictiveBackGestureEnabled": false,
       "permissions": [


### PR DESCRIPTION
Prépare la version mobile 1.4.2 avec les numéros de build Android/iOS incrémentés. Les correctifs de téléchargement VK et la nouvelle configuration de signature sont déjà présents sur la branche mobile.\n\nAprès fusion, le tag mobile-v1.4.2 sera utilisé par le workflow de release.