### PR TITLE
fix(mobile): migrate synchronization to Vkomic VK ID

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -32,7 +32,7 @@
       </intent-filter>
       <intent-filter data-generated="true">
         <action android:name="android.intent.action.VIEW"/>
-        <data android:scheme="https" android:host="oauth.vk.ru" android:pathPrefix="/blank.html"/>
+        <data android:scheme="vk54761286" android:host="vk.ru"/>
         <category android:name="android.intent.category.BROWSABLE"/>
         <category android:name="android.intent.category.DEFAULT"/>
       </intent-filter>

--- a/app.json
+++ b/app.json
@@ -2,7 +2,10 @@
   "expo": {
     "name": "vkomic",
     "slug": "vkomic-mobile",
-    "scheme": "vkomic",
+    "scheme": [
+      "vkomic",
+      "vk54761286"
+    ],
     "version": "1.4.2",
     "orientation": "default",
     "icon": "./assets/icon.png",
@@ -39,9 +42,8 @@
           "autoVerify": false,
           "data": [
             {
-              "scheme": "https",
-              "host": "oauth.vk.ru",
-              "pathPrefix": "/blank.html"
+              "scheme": "vk54761286",
+              "host": "vk.ru"
             }
           ],
           "category": [

--- a/src/components/VkAuthModal.tsx
+++ b/src/components/VkAuthModal.tsx
@@ -1,68 +1,66 @@
 import React, { useState } from "react";
-import { Modal, View, StyleSheet, Pressable, Text, TextInput, Alert } from "react-native";
+import { Modal, View, StyleSheet, Pressable, Text, Alert, ActivityIndicator } from "react-native";
 import * as WebBrowser from "expo-web-browser";
-import * as Clipboard from "expo-clipboard";
 import { Ionicons } from "@expo/vector-icons";
 import { palette, radius, spacing } from "../theme";
+import {
+    createVkAuthorizationRequest,
+    exchangeVkAuthorizationCode,
+    VK_ANDROID_REDIRECT_URI,
+    VkAuthSession,
+} from "../services/vk-auth";
 
-const VK_REDIRECT_URI = "https://oauth.vk.ru/blank.html";
-const VK_SCOPE = "docs";
+WebBrowser.maybeCompleteAuthSession();
 
 interface VkAuthModalProps {
-    appId: string;
     visible: boolean;
     onClose: () => void;
-    onSuccess: (token: string) => void;
+    onSuccess: (session: VkAuthSession) => Promise<void>;
 }
 
-export const VkAuthModal: React.FC<VkAuthModalProps> = ({ appId, visible, onClose, onSuccess }) => {
-    const [pastedUrl, setPastedUrl] = useState("");
-    const [step, setStep] = useState<"intro" | "paste">("intro");
-
-    const authUrl = `https://oauth.vk.ru/authorize?client_id=${encodeURIComponent(appId)}&scope=${VK_SCOPE}&redirect_uri=${encodeURIComponent(VK_REDIRECT_URI)}&display=page&response_type=token&v=5.199&revoke=1`;
+export const VkAuthModal: React.FC<VkAuthModalProps> = ({ visible, onClose, onSuccess }) => {
+    const [isConnecting, setIsConnecting] = useState(false);
 
     const openBrowser = async () => {
-        await WebBrowser.openBrowserAsync(authUrl);
-        setStep("paste");
-    };
+        setIsConnecting(true);
+        try {
+            const request = await createVkAuthorizationRequest();
+            const result = await WebBrowser.openAuthSessionAsync(request.url, VK_ANDROID_REDIRECT_URI);
+            if (result.type !== "success") return;
 
-    const handlePasteFromClipboard = async () => {
-        const text = await Clipboard.getStringAsync();
-        if (text) {
-            setPastedUrl(text);
-            tryExtractToken(text);
-        }
-    };
-
-    const tryExtractToken = (url: string) => {
-        if (url.includes("access_token=")) {
-            const fragment = url.split("#")[1] || url.split("access_token=")[1];
-            if (fragment) {
-                let tokenPart = fragment;
-                if (fragment.includes("access_token=")) {
-                    tokenPart = fragment.split("access_token=")[1];
-                }
-                const token = tokenPart.split("&")[0];
-                if (token && token.length > 10) {
-                    onSuccess(token);
-                    handleClose();
-                    return;
-                }
+            const callback = new URL(result.url);
+            const error = callback.searchParams.get("error");
+            if (error) {
+                throw new Error(callback.searchParams.get("error_description") || error);
             }
+            const returnedState = callback.searchParams.get("state");
+            const code = callback.searchParams.get("code");
+            const deviceId = callback.searchParams.get("device_id");
+            if (returnedState !== request.state || !code || !deviceId) {
+                throw new Error("La réponse de VK ID est incomplète ou ne correspond pas à la demande.");
+            }
+
+            const session = await exchangeVkAuthorizationCode(
+                code,
+                deviceId,
+                request.state,
+                request.codeVerifier,
+            );
+            await onSuccess(session);
+            onClose();
+        } catch (error) {
+            Alert.alert(
+                "Connexion VK impossible",
+                error instanceof Error ? error.message : "Une erreur inconnue est survenue.",
+            );
+        } finally {
+            setIsConnecting(false);
         }
-        Alert.alert("Erreur", "Impossible d'extraire le token. Vérifiez que vous avez copié l'URL complète.");
     };
 
     const handleClose = () => {
-        setStep("intro");
-        setPastedUrl("");
+        if (isConnecting) return;
         onClose();
-    };
-
-    const handleSubmit = () => {
-        if (pastedUrl.trim()) {
-            tryExtractToken(pastedUrl.trim());
-        }
     };
 
     return (
@@ -82,59 +80,27 @@ export const VkAuthModal: React.FC<VkAuthModalProps> = ({ appId, visible, onClos
                 </View>
 
                 <View style={styles.content}>
-                    {step === "intro" ? (
-                        <>
-                            <View style={styles.iconCircle}>
-                                <Ionicons name="logo-vk" size={48} color="#4C75A3" />
-                            </View>
-                            <Text style={styles.title}>Se connecter avec VK</Text>
-                            <Text style={styles.desc}>
-                                Vous allez être redirigé vers VK pour vous connecter. Après connexion, copiez l'URL de la page blanche.
-                            </Text>
-                            <Pressable style={styles.primaryBtn} onPress={openBrowser}>
-                                <Ionicons name="open-outline" size={20} color="#fff" />
-                                <Text style={styles.primaryBtnText}>Ouvrir VK</Text>
-                            </Pressable>
-                        </>
-                    ) : (
-                        <>
-                            <View style={styles.iconCircle}>
-                                <Ionicons name="clipboard" size={48} color={palette.primary} />
-                            </View>
-                            <Text style={styles.title}>Coller l'URL</Text>
-                            <Text style={styles.desc}>
-                                Après vous être connecté, vous avez été redirigé vers une page blanche.{"\n\n"}
-                                <Text style={{ fontWeight: "900" }}>Copiez l'URL complète</Text> de cette page et collez-la ci-dessous :
-                            </Text>
-                            <TextInput
-                                style={styles.input}
-                                placeholder="https://oauth.vk.ru/blank.html#access_token=..."
-                                placeholderTextColor={palette.muted}
-                                value={pastedUrl}
-                                onChangeText={setPastedUrl}
-                                autoCapitalize="none"
-                                autoCorrect={false}
-                                multiline
-                            />
-                            <View style={styles.btnRow}>
-                                <Pressable style={styles.secondaryBtn} onPress={handlePasteFromClipboard}>
-                                    <Ionicons name="clipboard-outline" size={18} color={palette.primary} />
-                                    <Text style={styles.secondaryBtnText}>Coller</Text>
-                                </Pressable>
-                                <Pressable
-                                    style={[styles.primaryBtn, { flex: 1 }]}
-                                    onPress={handleSubmit}
-                                    disabled={!pastedUrl.trim()}
-                                >
-                                    <Ionicons name="checkmark" size={20} color="#fff" />
-                                    <Text style={styles.primaryBtnText}>Valider</Text>
-                                </Pressable>
-                            </View>
-                            <Pressable style={styles.linkBtn} onPress={openBrowser}>
-                                <Text style={styles.linkBtnText}>Réessayer la connexion</Text>
-                            </Pressable>
-                        </>
-                    )}
+                    <View style={styles.iconCircle}>
+                        <Ionicons name="logo-vk" size={48} color="#4C75A3" />
+                    </View>
+                    <Text style={styles.title}>Se connecter avec VK ID</Text>
+                    <Text style={styles.desc}>
+                        VK ID va ouvrir une fenêtre sécurisée puis revenir automatiquement dans Vkomic. Aucun mot de passe ni token ne sera copié manuellement.
+                    </Text>
+                    <Pressable
+                        style={[styles.primaryBtn, isConnecting && { opacity: 0.65 }]}
+                        onPress={openBrowser}
+                        disabled={isConnecting}
+                    >
+                        {isConnecting ? (
+                            <ActivityIndicator color="#fff" />
+                        ) : (
+                            <Ionicons name="open-outline" size={20} color="#fff" />
+                        )}
+                        <Text style={styles.primaryBtnText}>
+                            {isConnecting ? "Connexion…" : "Continuer avec VK ID"}
+                        </Text>
+                    </Pressable>
                 </View>
             </View>
         </Modal>
@@ -215,48 +181,5 @@ const styles = StyleSheet.create({
         color: "#fff",
         fontSize: 16,
         fontWeight: "900",
-    },
-    secondaryBtn: {
-        flexDirection: "row",
-        alignItems: "center",
-        justifyContent: "center",
-        gap: spacing.xs,
-        backgroundColor: `${palette.primary}15`,
-        paddingVertical: spacing.md,
-        paddingHorizontal: spacing.lg,
-        borderRadius: radius.lg,
-        borderWidth: 1,
-        borderColor: `${palette.primary}30`,
-    },
-    secondaryBtnText: {
-        color: palette.primary,
-        fontSize: 14,
-        fontWeight: "800",
-    },
-    input: {
-        width: "100%",
-        backgroundColor: palette.surface,
-        borderRadius: radius.md,
-        borderWidth: 1,
-        borderColor: palette.border,
-        padding: spacing.md,
-        color: palette.text,
-        fontSize: 13,
-        minHeight: 80,
-        marginBottom: spacing.md,
-    },
-    btnRow: {
-        flexDirection: "row",
-        gap: spacing.sm,
-        width: "100%",
-    },
-    linkBtn: {
-        marginTop: spacing.lg,
-        padding: spacing.sm,
-    },
-    linkBtnText: {
-        color: palette.muted,
-        fontSize: 13,
-        textDecorationLine: "underline",
     },
 });

--- a/src/components/VkAuthModal.tsx
+++ b/src/components/VkAuthModal.tsx
@@ -5,22 +5,21 @@ import * as Clipboard from "expo-clipboard";
 import { Ionicons } from "@expo/vector-icons";
 import { palette, radius, spacing } from "../theme";
 
-// Kate Mobile App ID (Public)
-const VK_APP_ID = "2685278";
 const VK_REDIRECT_URI = "https://oauth.vk.ru/blank.html";
-const VK_SCOPE = "docs,groups,wall,offline";
+const VK_SCOPE = "docs";
 
 interface VkAuthModalProps {
+    appId: string;
     visible: boolean;
     onClose: () => void;
     onSuccess: (token: string) => void;
 }
 
-export const VkAuthModal: React.FC<VkAuthModalProps> = ({ visible, onClose, onSuccess }) => {
+export const VkAuthModal: React.FC<VkAuthModalProps> = ({ appId, visible, onClose, onSuccess }) => {
     const [pastedUrl, setPastedUrl] = useState("");
     const [step, setStep] = useState<"intro" | "paste">("intro");
 
-    const authUrl = `https://oauth.vk.ru/authorize?client_id=${VK_APP_ID}&scope=${VK_SCOPE}&redirect_uri=${VK_REDIRECT_URI}&response_type=token&v=5.199&revoke=1`;
+    const authUrl = `https://oauth.vk.ru/authorize?client_id=${encodeURIComponent(appId)}&scope=${VK_SCOPE}&redirect_uri=${encodeURIComponent(VK_REDIRECT_URI)}&display=page&response_type=token&v=5.199&revoke=1`;
 
     const openBrowser = async () => {
         await WebBrowser.openBrowserAsync(authUrl);

--- a/src/context/AppDataContext.tsx
+++ b/src/context/AppDataContext.tsx
@@ -75,7 +75,7 @@ const STORAGE_KEYS = {
 
 const DOWNLOAD_DIR_NAME = "vkomic-downloads";
 const VK_DOWNLOAD_HEADERS = {
-  "User-Agent": "KateMobileAndroid/110.1 lite-x86_64 (Android 11; SDK 30; x86_64; en)",
+  "User-Agent": "Vkomic/1.4.2 (+https://github.com/G-kylexy/vkomic)",
   Accept: "*/*",
   "Accept-Encoding": "identity",
 };

--- a/src/context/VkContext.tsx
+++ b/src/context/VkContext.tsx
@@ -1,5 +1,5 @@
 import React, { createContext, useContext, useEffect, useState, useCallback } from "react";
-import { Platform, Linking } from "react-native";
+import { Platform } from "react-native";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import * as Network from "expo-network";
 import * as SecureStore from "expo-secure-store";
@@ -7,8 +7,12 @@ import { Language } from "../i18n";
 import { VkConnectionStatus } from "../types";
 import { palette } from "../theme";
 import * as FolderService from "../services/FolderService";
+import { refreshVkAccessToken, VkAuthSession } from "../services/vk-auth";
 
 const VK_TOKEN_STORAGE_KEY = "vk_token";
+const VK_REFRESH_TOKEN_STORAGE_KEY = "vk_refresh_token";
+const VK_DEVICE_ID_STORAGE_KEY = "vk_device_id";
+const VK_EXPIRES_AT_STORAGE_KEY = "vk_token_expires_at";
 
 const readStoredToken = async (): Promise<string | null> => {
     if (Platform.OS === "web") {
@@ -40,13 +44,26 @@ const persistToken = async (value: string): Promise<void> => {
     await AsyncStorage.removeItem(VK_TOKEN_STORAGE_KEY);
 };
 
+const readSecret = async (key: string): Promise<string | null> => {
+    if (Platform.OS === "web") return AsyncStorage.getItem(key);
+    return SecureStore.getItemAsync(key);
+};
+
+const persistSecret = async (key: string, value: string): Promise<void> => {
+    if (Platform.OS === "web") {
+        if (value) await AsyncStorage.setItem(key, value);
+        else await AsyncStorage.removeItem(key);
+        return;
+    }
+    if (value) await SecureStore.setItemAsync(key, value);
+    else await SecureStore.deleteItemAsync(key);
+    await AsyncStorage.removeItem(key);
+};
+
 // Contexte global des réglages VK côté mobile.
 // Objectif: reproduire la persistance du desktop (localStorage/IDB) avec AsyncStorage (mobile).
 interface VkContextType {
     token: string;
-    setToken: (token: string) => Promise<void>;
-    appId: string;
-    setAppId: (appId: string) => Promise<void>;
     groupId: string;
     setGroupId: (groupId: string) => Promise<void>;
     topicId: string;
@@ -64,7 +81,7 @@ interface VkContextType {
     isOffline: boolean;
     showAuthModal: boolean;
     setShowAuthModal: (show: boolean) => void;
-    handleAuthSuccess: (token: string) => Promise<void>;
+    handleAuthSuccess: (session: VkAuthSession) => Promise<void>;
     logout: () => Promise<void>;
 }
 
@@ -74,7 +91,9 @@ export const VkProvider: React.FC<{ children: React.ReactNode }> = ({
     children,
 }) => {
     const [token, setTokenState] = useState("");
-    const [appId, setAppIdState] = useState("");
+    const [refreshToken, setRefreshToken] = useState("");
+    const [deviceId, setDeviceId] = useState("");
+    const [tokenExpiresAt, setTokenExpiresAt] = useState(0);
     const [groupId, setGroupIdState] = useState("203785966");
     const [topicId, setTopicIdState] = useState("47515406");
     const [language, setLanguageState] = useState<Language>("fr");
@@ -107,63 +126,6 @@ export const VkProvider: React.FC<{ children: React.ReactNode }> = ({
         return () => clearInterval(interval);
     }, [checkNetworkStatus]);
 
-    // Parse token from VK OAuth URL
-    const parseTokenFromUrl = useCallback((url: string): string | null => {
-        try {
-            // URL format: https://oauth.vk.ru/blank.html#access_token=...&expires_in=...&user_id=...
-            const hashIndex = url.indexOf('#');
-            if (hashIndex === -1) return null;
-
-            const fragment = url.substring(hashIndex + 1);
-            const params = new URLSearchParams(fragment);
-            const accessToken = params.get('access_token');
-
-            if (accessToken && accessToken.length > 10) {
-                return accessToken;
-            }
-            return null;
-        } catch {
-            return null;
-        }
-    }, []);
-
-    // Handle incoming deep links (shared URLs from browser)
-    useEffect(() => {
-        const handleUrl = async (event: { url: string }) => {
-            const extractedToken = parseTokenFromUrl(event.url);
-            if (extractedToken) {
-                // Save token directly (same logic as setToken)
-                setTokenState(extractedToken);
-                setStatus((prev) => ({ ...prev, connected: true }));
-                try {
-                    await persistToken(extractedToken);
-                } catch (e) {
-                    console.error("Failed to save token from URL", e);
-                }
-            }
-        };
-
-        // Check if app was opened with a URL
-        const checkInitialUrl = async () => {
-            const initialUrl = await Linking.getInitialURL();
-            if (initialUrl) {
-                await handleUrl({ url: initialUrl });
-            }
-        };
-
-        // Listen for URL events while app is running
-        const subscription = Linking.addEventListener('url', handleUrl);
-
-        // Check initial URL after settings are loaded
-        if (isReady) {
-            void checkInitialUrl();
-        }
-
-        return () => {
-            subscription.remove();
-        };
-    }, [isReady, parseTokenFromUrl]);
-
     // Hydrate les réglages sauvegardés (au démarrage).
     useEffect(() => {
         let isMounted = true;
@@ -178,7 +140,9 @@ export const VkProvider: React.FC<{ children: React.ReactNode }> = ({
             try {
                 const [
                     savedToken,
-                    savedAppId,
+                    savedRefreshToken,
+                    savedDeviceId,
+                    savedExpiresAt,
                     savedPath,
                     savedGroupId,
                     savedTopicId,
@@ -186,7 +150,9 @@ export const VkProvider: React.FC<{ children: React.ReactNode }> = ({
                     savedAutoSync,
                 ] = await Promise.all([
                     readStoredToken(),
-                    AsyncStorage.getItem("vk_app_id"),
+                    readSecret(VK_REFRESH_TOKEN_STORAGE_KEY),
+                    readSecret(VK_DEVICE_ID_STORAGE_KEY),
+                    readSecret(VK_EXPIRES_AT_STORAGE_KEY),
                     AsyncStorage.getItem("vk_download_path"),
                     AsyncStorage.getItem("vk_group_id"),
                     AsyncStorage.getItem("vk_topic_id"),
@@ -196,11 +162,24 @@ export const VkProvider: React.FC<{ children: React.ReactNode }> = ({
 
                 if (!isMounted) return;
 
-                if (savedToken) {
+                const savedExpiry = Number(savedExpiresAt) || 0;
+                if (savedToken && savedRefreshToken && savedDeviceId && savedExpiry) {
                     setTokenState(savedToken);
+                    setRefreshToken(savedRefreshToken);
+                    setDeviceId(savedDeviceId);
+                    setTokenExpiresAt(savedExpiry);
                     setStatus((prev) => ({ ...prev, connected: true }));
+                } else if (savedToken || savedRefreshToken || savedDeviceId || savedExpiresAt) {
+                    // Tokens from the legacy Kate Mobile flow have no valid VK ID
+                    // refresh session and must never be reused by Vkomic.
+                    await Promise.all([
+                        persistToken(""),
+                        persistSecret(VK_REFRESH_TOKEN_STORAGE_KEY, ""),
+                        persistSecret(VK_DEVICE_ID_STORAGE_KEY, ""),
+                        persistSecret(VK_EXPIRES_AT_STORAGE_KEY, ""),
+                    ]);
                 }
-                if (savedAppId) setAppIdState(savedAppId);
+                await AsyncStorage.removeItem("vk_app_id");
                 if (savedPath) {
                     // Check SAF permissions if it's a content:// URI
                     if (Platform.OS === "android" && savedPath.startsWith("content://")) {
@@ -241,32 +220,24 @@ export const VkProvider: React.FC<{ children: React.ReactNode }> = ({
         return () => { isMounted = false; clearTimeout(safetyTimeout); };
     }, []);
 
-    // Sauvegarde native chiffrée (Keychain iOS / Keystore Android).
-    const setToken = async (newToken: string) => {
-        setTokenState(newToken);
+    // Efface toute la session VK ID des stockages natifs chiffrés.
+    const clearAuthSession = useCallback(async () => {
+        setTokenState("");
         try {
-            if (newToken) {
-                await persistToken(newToken);
-                setStatus((prev) => ({ ...prev, connected: true }));
-            } else {
-                await persistToken("");
-                setStatus((prev) => ({ ...prev, connected: false }));
-            }
+            await Promise.all([
+                persistToken(""),
+                persistSecret(VK_REFRESH_TOKEN_STORAGE_KEY, ""),
+                persistSecret(VK_DEVICE_ID_STORAGE_KEY, ""),
+                persistSecret(VK_EXPIRES_AT_STORAGE_KEY, ""),
+            ]);
         } catch (e) {
-            console.error("Failed to save token", e);
+            console.error("Failed to clear VK ID session", e);
         }
-    };
-
-    const setAppId = async (newAppId: string) => {
-        const normalized = newAppId.replace(/[^\d]/g, "");
-        setAppIdState(normalized);
-        try {
-            if (normalized) await AsyncStorage.setItem("vk_app_id", normalized);
-            else await AsyncStorage.removeItem("vk_app_id");
-        } catch (e) {
-            console.error("Failed to save VK App ID", e);
-        }
-    };
+        setRefreshToken("");
+        setDeviceId("");
+        setTokenExpiresAt(0);
+        setStatus((prev) => ({ ...prev, connected: false }));
+    }, []);
 
     // Group/Topic: permet de pointer vers une autre board si besoin (mêmes valeurs par défaut que le desktop).
     const setGroupId = async (newGroupId: string) => {
@@ -317,22 +288,50 @@ export const VkProvider: React.FC<{ children: React.ReactNode }> = ({
 
     const activePalette = palette;
 
-    // Handle successful auth from modal
-    const handleAuthSuccess = async (accessToken: string) => {
-        await setToken(accessToken);
-    };
+    const persistAuthSession = useCallback(async (session: VkAuthSession) => {
+        setTokenState(session.accessToken);
+        setRefreshToken(session.refreshToken);
+        setDeviceId(session.deviceId);
+        setTokenExpiresAt(session.expiresAt);
+        await Promise.all([
+            persistToken(session.accessToken),
+            persistSecret(VK_REFRESH_TOKEN_STORAGE_KEY, session.refreshToken),
+            persistSecret(VK_DEVICE_ID_STORAGE_KEY, session.deviceId),
+            persistSecret(VK_EXPIRES_AT_STORAGE_KEY, String(session.expiresAt)),
+        ]);
+        setStatus((prev) => ({ ...prev, connected: true, errorCode: null }));
+    }, []);
+
+    // Handle successful OAuth 2.1 + PKCE authentication from the modal.
+    const handleAuthSuccess = useCallback(async (session: VkAuthSession) => {
+        await persistAuthSession(session);
+    }, [persistAuthSession]);
+
+    // VK ID access tokens expire quickly. Refresh one minute before expiration.
+    useEffect(() => {
+        if (!isReady || !refreshToken || !deviceId || !tokenExpiresAt) return;
+        const delay = Math.max(tokenExpiresAt - Date.now() - 60_000, 1_000);
+        const timer = setTimeout(() => {
+            void refreshVkAccessToken(refreshToken, deviceId)
+                .then(persistAuthSession)
+                .catch((error) => {
+                    console.error("VK ID token refresh failed", error);
+                    void clearAuthSession().then(() => {
+                        setStatus((prev) => ({ ...prev, errorCode: 5 }));
+                    });
+                });
+        }, delay);
+        return () => clearTimeout(timer);
+    }, [isReady, refreshToken, deviceId, tokenExpiresAt, persistAuthSession, clearAuthSession]);
 
     // Logout - clear token
     const logout = async () => {
-        await setToken("");
+        await clearAuthSession();
         setStatus(prev => ({ ...prev, connected: false, latencyMs: null, errorCode: null }));
     };
 
     const value = React.useMemo(() => ({
         token,
-        setToken,
-        appId,
-        setAppId,
         groupId,
         setGroupId,
         topicId,
@@ -353,8 +352,8 @@ export const VkProvider: React.FC<{ children: React.ReactNode }> = ({
         handleAuthSuccess,
         logout,
     }), [
-        token, appId, groupId, topicId, language, downloadPath, status, isReady,
-        autoSync, activePalette, isOffline, showAuthModal, parseTokenFromUrl,
+        token, groupId, topicId, language, downloadPath, status, isReady,
+        autoSync, activePalette, isOffline, showAuthModal,
         // Including functions here would trigger re-renders anyway without useCallback, 
         // but removing them from deps might cause stale closures if they weren't generic.
         // For now, this restores functionality.

--- a/src/context/VkContext.tsx
+++ b/src/context/VkContext.tsx
@@ -8,10 +8,6 @@ import { VkConnectionStatus } from "../types";
 import { palette } from "../theme";
 import * as FolderService from "../services/FolderService";
 
-// VK OAuth Configuration
-const VK_APP_ID = "2685278"; // VK Android app ID (public)
-const VK_REDIRECT_URI = "https://oauth.vk.ru/blank.html";
-const VK_SCOPE = "docs,groups,wall,offline";
 const VK_TOKEN_STORAGE_KEY = "vk_token";
 
 const readStoredToken = async (): Promise<string | null> => {
@@ -49,6 +45,8 @@ const persistToken = async (value: string): Promise<void> => {
 interface VkContextType {
     token: string;
     setToken: (token: string) => Promise<void>;
+    appId: string;
+    setAppId: (appId: string) => Promise<void>;
     groupId: string;
     setGroupId: (groupId: string) => Promise<void>;
     topicId: string;
@@ -76,6 +74,7 @@ export const VkProvider: React.FC<{ children: React.ReactNode }> = ({
     children,
 }) => {
     const [token, setTokenState] = useState("");
+    const [appId, setAppIdState] = useState("");
     const [groupId, setGroupIdState] = useState("203785966");
     const [topicId, setTopicIdState] = useState("47515406");
     const [language, setLanguageState] = useState<Language>("fr");
@@ -179,6 +178,7 @@ export const VkProvider: React.FC<{ children: React.ReactNode }> = ({
             try {
                 const [
                     savedToken,
+                    savedAppId,
                     savedPath,
                     savedGroupId,
                     savedTopicId,
@@ -186,6 +186,7 @@ export const VkProvider: React.FC<{ children: React.ReactNode }> = ({
                     savedAutoSync,
                 ] = await Promise.all([
                     readStoredToken(),
+                    AsyncStorage.getItem("vk_app_id"),
                     AsyncStorage.getItem("vk_download_path"),
                     AsyncStorage.getItem("vk_group_id"),
                     AsyncStorage.getItem("vk_topic_id"),
@@ -199,6 +200,7 @@ export const VkProvider: React.FC<{ children: React.ReactNode }> = ({
                     setTokenState(savedToken);
                     setStatus((prev) => ({ ...prev, connected: true }));
                 }
+                if (savedAppId) setAppIdState(savedAppId);
                 if (savedPath) {
                     // Check SAF permissions if it's a content:// URI
                     if (Platform.OS === "android" && savedPath.startsWith("content://")) {
@@ -252,6 +254,17 @@ export const VkProvider: React.FC<{ children: React.ReactNode }> = ({
             }
         } catch (e) {
             console.error("Failed to save token", e);
+        }
+    };
+
+    const setAppId = async (newAppId: string) => {
+        const normalized = newAppId.replace(/[^\d]/g, "");
+        setAppIdState(normalized);
+        try {
+            if (normalized) await AsyncStorage.setItem("vk_app_id", normalized);
+            else await AsyncStorage.removeItem("vk_app_id");
+        } catch (e) {
+            console.error("Failed to save VK App ID", e);
         }
     };
 
@@ -318,6 +331,8 @@ export const VkProvider: React.FC<{ children: React.ReactNode }> = ({
     const value = React.useMemo(() => ({
         token,
         setToken,
+        appId,
+        setAppId,
         groupId,
         setGroupId,
         topicId,
@@ -338,7 +353,7 @@ export const VkProvider: React.FC<{ children: React.ReactNode }> = ({
         handleAuthSuccess,
         logout,
     }), [
-        token, groupId, topicId, language, downloadPath, status, isReady,
+        token, appId, groupId, topicId, language, downloadPath, status, isReady,
         autoSync, activePalette, isOffline, showAuthModal, parseTokenFromUrl,
         // Including functions here would trigger re-renders anyway without useCallback, 
         // but removing them from deps might cause stale closures if they weren't generic.

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -26,9 +26,6 @@ import { requestFolderPermission, getFolderDisplayName } from "../services/Folde
 export const SettingsScreen: React.FC = () => {
   const {
     token,
-    setToken,
-    appId,
-    setAppId,
     groupId,
     setGroupId,
     topicId,
@@ -52,8 +49,6 @@ export const SettingsScreen: React.FC = () => {
   const accent = tabAccents.settings;
 
   // États locaux pour tous les paramètres modifiables
-  const [localToken, setLocalToken] = useState(token);
-  const [localAppId, setLocalAppId] = useState(appId);
   const [localGroupId, setLocalGroupId] = useState(groupId);
   const [localTopicId, setLocalTopicId] = useState(topicId);
   const [saved, setSaved] = useState(false);
@@ -67,36 +62,9 @@ export const SettingsScreen: React.FC = () => {
   const [resetDialog, setResetDialog] = useState(false);
 
   // Vérifier si quelque chose a changé
-  const hasChanges = localToken !== token || localAppId !== appId || localGroupId !== groupId || localTopicId !== topicId;
-
-  // Sync localToken when context token changes (e.g. via deep link or auth modal)
-  React.useEffect(() => {
-    setLocalToken(token);
-  }, [token]);
-
-  React.useEffect(() => {
-    setLocalAppId(appId);
-  }, [appId]);
-
-  const handleTokenChange = (text: string) => {
-    // Check if pasted text is a VK OAuth URL
-    if (text.includes("access_token=")) {
-      try {
-        const match = text.match(/access_token=([^&]+)/);
-        if (match && match[1]) {
-          setLocalToken(match[1]);
-          return;
-        }
-      } catch (e) {
-        // Fallback to normal text
-      }
-    }
-    setLocalToken(text);
-  };
+  const hasChanges = localGroupId !== groupId || localTopicId !== topicId;
 
   const handleSaveAll = async () => {
-    if (localToken !== token) void setToken(localToken);
-    if (localAppId !== appId) void setAppId(localAppId);
     if (localGroupId !== groupId) {
       void setGroupId(localGroupId);
       void clearCache();
@@ -116,14 +84,6 @@ export const SettingsScreen: React.FC = () => {
   };
 
   const openAuth = () => {
-    if (!localAppId.trim()) {
-      Alert.alert(
-        "VK App ID requis",
-        "Créez votre propre application VK, puis saisissez son identifiant ici. Vkomic n'utilise plus l'identité d'une application tierce."
-      );
-      return;
-    }
-    void setAppId(localAppId);
     setShowAuthModal(true);
   };
 
@@ -213,34 +173,6 @@ export const SettingsScreen: React.FC = () => {
               </Pressable>
             </View>
           )}
-
-          <View style={[styles.cardItem, { marginTop: spacing.md }]}>
-            <Text style={[styles.label, { color: palette.muted }]}>VK App ID (votre application)</Text>
-            <TextInput
-              value={localAppId}
-              onChangeText={(value: string) => setLocalAppId(value.replace(/[^\d]/g, ""))}
-              placeholder="ID de votre application VK"
-              placeholderTextColor={palette.subtle}
-              style={[styles.input, { backgroundColor: palette.surface, borderColor: `${palette.border}80`, color: palette.text, marginTop: spacing.xs }]}
-              keyboardType="number-pad"
-            />
-            <Text style={{ color: palette.muted, fontSize: 12, marginTop: spacing.xs }}>N'utilisez pas l'App ID de Kate Mobile ou d'une autre application tierce.</Text>
-          </View>
-
-          {/* Manual token input (advanced) */}
-          <View style={[styles.cardItem, { marginTop: spacing.md }]}>
-            <Text style={[styles.label, { color: palette.muted }]}>Token manuel (avancé)</Text>
-            <TextInput
-              value={localToken}
-              onChangeText={handleTokenChange}
-              placeholder="vk1.a..."
-              placeholderTextColor={palette.subtle}
-              style={[styles.input, { backgroundColor: palette.surface, borderColor: `${palette.border}80`, color: palette.text, marginTop: spacing.xs }]}
-              secureTextEntry
-              autoCapitalize="none"
-              autoCorrect={false}
-            />
-          </View>
 
           <View style={styles.rowInputs}>
             <View style={styles.half}>
@@ -418,7 +350,6 @@ export const SettingsScreen: React.FC = () => {
 
       {/* Login VK Modal */}
       <VkAuthModal
-        appId={localAppId}
         visible={showAuthModal}
         onClose={() => setShowAuthModal(false)}
         onSuccess={handleAuthSuccess}

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from "react";
 import Constants from "expo-constants";
-import * as WebBrowser from "expo-web-browser";
 import {
   ScrollView,
   StyleSheet,
@@ -28,6 +27,8 @@ export const SettingsScreen: React.FC = () => {
   const {
     token,
     setToken,
+    appId,
+    setAppId,
     groupId,
     setGroupId,
     topicId,
@@ -52,6 +53,7 @@ export const SettingsScreen: React.FC = () => {
 
   // États locaux pour tous les paramètres modifiables
   const [localToken, setLocalToken] = useState(token);
+  const [localAppId, setLocalAppId] = useState(appId);
   const [localGroupId, setLocalGroupId] = useState(groupId);
   const [localTopicId, setLocalTopicId] = useState(topicId);
   const [saved, setSaved] = useState(false);
@@ -65,12 +67,16 @@ export const SettingsScreen: React.FC = () => {
   const [resetDialog, setResetDialog] = useState(false);
 
   // Vérifier si quelque chose a changé
-  const hasChanges = localToken !== token || localGroupId !== groupId || localTopicId !== topicId;
+  const hasChanges = localToken !== token || localAppId !== appId || localGroupId !== groupId || localTopicId !== topicId;
 
   // Sync localToken when context token changes (e.g. via deep link or auth modal)
   React.useEffect(() => {
     setLocalToken(token);
   }, [token]);
+
+  React.useEffect(() => {
+    setLocalAppId(appId);
+  }, [appId]);
 
   const handleTokenChange = (text: string) => {
     // Check if pasted text is a VK OAuth URL
@@ -90,6 +96,7 @@ export const SettingsScreen: React.FC = () => {
 
   const handleSaveAll = async () => {
     if (localToken !== token) void setToken(localToken);
+    if (localAppId !== appId) void setAppId(localAppId);
     if (localGroupId !== groupId) {
       void setGroupId(localGroupId);
       void clearCache();
@@ -108,9 +115,16 @@ export const SettingsScreen: React.FC = () => {
     setLocalTopicId("47515406");
   };
 
-  const openAuth = async () => {
-    const url = "https://oauth.vk.ru/authorize?client_id=2685278&scope=offline,docs,groups,wall&redirect_uri=https://oauth.vk.ru/blank.html&display=page&response_type=token&revoke=1";
-    await WebBrowser.openBrowserAsync(url);
+  const openAuth = () => {
+    if (!localAppId.trim()) {
+      Alert.alert(
+        "VK App ID requis",
+        "Créez votre propre application VK, puis saisissez son identifiant ici. Vkomic n'utilise plus l'identité d'une application tierce."
+      );
+      return;
+    }
+    void setAppId(localAppId);
+    setShowAuthModal(true);
   };
 
 
@@ -181,7 +195,7 @@ export const SettingsScreen: React.FC = () => {
           {!token ? (
             <Pressable
               style={[styles.vkLoginBtn, { backgroundColor: "#4C75A3" }]}
-              onPress={() => setShowAuthModal(true)}
+              onPress={openAuth}
             >
               <Ionicons name="logo-vk" size={24} color="#fff" />
               <Text style={styles.vkLoginText}>Se connecter avec VK</Text>
@@ -199,6 +213,19 @@ export const SettingsScreen: React.FC = () => {
               </Pressable>
             </View>
           )}
+
+          <View style={[styles.cardItem, { marginTop: spacing.md }]}>
+            <Text style={[styles.label, { color: palette.muted }]}>VK App ID (votre application)</Text>
+            <TextInput
+              value={localAppId}
+              onChangeText={(value: string) => setLocalAppId(value.replace(/[^\d]/g, ""))}
+              placeholder="ID de votre application VK"
+              placeholderTextColor={palette.subtle}
+              style={[styles.input, { backgroundColor: palette.surface, borderColor: `${palette.border}80`, color: palette.text, marginTop: spacing.xs }]}
+              keyboardType="number-pad"
+            />
+            <Text style={{ color: palette.muted, fontSize: 12, marginTop: spacing.xs }}>N'utilisez pas l'App ID de Kate Mobile ou d'une autre application tierce.</Text>
+          </View>
 
           {/* Manual token input (advanced) */}
           <View style={[styles.cardItem, { marginTop: spacing.md }]}>
@@ -391,6 +418,7 @@ export const SettingsScreen: React.FC = () => {
 
       {/* Login VK Modal */}
       <VkAuthModal
+        appId={localAppId}
         visible={showAuthModal}
         onClose={() => setShowAuthModal(false)}
         onSuccess={handleAuthSuccess}

--- a/src/services/vk-auth.ts
+++ b/src/services/vk-auth.ts
@@ -1,0 +1,125 @@
+import * as Crypto from "expo-crypto";
+
+export const VK_ANDROID_CLIENT_ID = "54761286";
+export const VK_ANDROID_REDIRECT_URI = `vk${VK_ANDROID_CLIENT_ID}://vk.ru`;
+export const VK_AUTHORIZATION_ENDPOINT = "https://id.vk.ru/authorize";
+export const VK_TOKEN_ENDPOINT = "https://id.vk.ru/oauth2/auth";
+export const VK_API_SCOPE = "docs";
+
+export interface VkAuthSession {
+  accessToken: string;
+  refreshToken: string;
+  deviceId: string;
+  expiresAt: number;
+}
+
+interface VkTokenResponse {
+  access_token?: string;
+  refresh_token?: string;
+  expires_in?: number;
+  device_id?: string;
+  state?: string;
+  error?: string;
+  error_description?: string;
+}
+
+const randomHex = async (byteLength: number): Promise<string> => {
+  const bytes = await Crypto.getRandomBytesAsync(byteLength);
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
+};
+
+const base64Url = (value: string): string =>
+  value.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+
+export const createVkAuthorizationRequest = async (): Promise<{
+  url: string;
+  state: string;
+  codeVerifier: string;
+}> => {
+  const [state, codeVerifier] = await Promise.all([randomHex(24), randomHex(32)]);
+  const digest = await Crypto.digestStringAsync(
+    Crypto.CryptoDigestAlgorithm.SHA256,
+    codeVerifier,
+    { encoding: Crypto.CryptoEncoding.BASE64 },
+  );
+
+  const params = new URLSearchParams({
+    client_id: VK_ANDROID_CLIENT_ID,
+    redirect_uri: VK_ANDROID_REDIRECT_URI,
+    response_type: "code",
+    code_challenge: base64Url(digest),
+    code_challenge_method: "s256",
+    state,
+    scope: VK_API_SCOPE,
+  });
+
+  return {
+    url: `${VK_AUTHORIZATION_ENDPOINT}?${params.toString()}`,
+    state,
+    codeVerifier,
+  };
+};
+
+const parseTokenResponse = async (
+  response: Response,
+  expectedState: string,
+  fallbackDeviceId: string,
+): Promise<VkAuthSession> => {
+  const data = (await response.json()) as VkTokenResponse;
+  if (!response.ok || data.error || !data.access_token || !data.refresh_token) {
+    throw new Error(data.error_description || data.error || "VK ID a refusé la connexion.");
+  }
+  if (data.state && data.state !== expectedState) {
+    throw new Error("La réponse VK ID ne correspond pas à la demande de connexion.");
+  }
+
+  const expiresIn = Math.max(Number(data.expires_in || 3600), 60);
+  return {
+    accessToken: data.access_token,
+    refreshToken: data.refresh_token,
+    deviceId: data.device_id || fallbackDeviceId,
+    expiresAt: Date.now() + expiresIn * 1000,
+  };
+};
+
+export const exchangeVkAuthorizationCode = async (
+  code: string,
+  deviceId: string,
+  state: string,
+  codeVerifier: string,
+): Promise<VkAuthSession> => {
+  const query = new URLSearchParams({
+    grant_type: "authorization_code",
+    redirect_uri: VK_ANDROID_REDIRECT_URI,
+    client_id: VK_ANDROID_CLIENT_ID,
+    code_verifier: codeVerifier,
+    state,
+    device_id: deviceId,
+  });
+  const response = await fetch(`${VK_TOKEN_ENDPOINT}?${query.toString()}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({ code }).toString(),
+  });
+  return parseTokenResponse(response, state, deviceId);
+};
+
+export const refreshVkAccessToken = async (
+  refreshToken: string,
+  deviceId: string,
+): Promise<VkAuthSession> => {
+  const state = await randomHex(24);
+  const query = new URLSearchParams({
+    grant_type: "refresh_token",
+    redirect_uri: VK_ANDROID_REDIRECT_URI,
+    client_id: VK_ANDROID_CLIENT_ID,
+    state,
+    device_id: deviceId,
+  });
+  const response = await fetch(`${VK_TOKEN_ENDPOINT}?${query.toString()}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({ refresh_token: refreshToken }).toString(),
+  });
+  return parseTokenResponse(response, state, deviceId);
+};

--- a/src/services/vk-service.ts
+++ b/src/services/vk-service.ts
@@ -30,7 +30,7 @@ const executeRequest = <T>(url: string): Promise<T> => {
       try {
         const res = await fetch(url, {
           headers: {
-            "User-Agent": "KateMobileAndroid/110.1 lite-x86_64 (Android 11; SDK 30; x86_64; en)",
+            "User-Agent": "Vkomic/1.4.2 (+https://github.com/G-kylexy/vkomic)",
             Accept: "application/json",
           },
           signal: controller.signal,
@@ -78,47 +78,12 @@ const runParallel = async <T, R>(
 export const fetchVkTopic = async (
   token: string,
   groupId: string,
-  topicId: string
+  topicId: string,
+  offset: number = 0
 ): Promise<any> => {
   if (!token || token.length < 10) throw new Error("Invalid Token");
-  const url = `https://api.vk.ru/method/board.getComments?access_token=${token}&group_id=${groupId}&topic_id=${topicId}&count=100&extended=1&v=${API_VERSION}`;
+  const url = `https://api.vk.ru/method/board.getComments?access_token=${token}&group_id=${groupId}&topic_id=${topicId}&count=100&offset=${offset}&extended=1&v=${API_VERSION}`;
   return executeRequest(url);
-};
-
-// Version batch via VK execute pour plusieurs offsets
-const fetchVkTopicBatch = async (
-  token: string,
-  groupId: string,
-  topicId: string,
-  offsets: number[]
-): Promise<any[]> => {
-  if (!token || token.length < 10) throw new Error("Invalid Token");
-  const offsetsLiteral = offsets.join(",");
-  const code = `
-    var offsets = [${offsetsLiteral}];
-    var res = [];
-    var i = 0;
-    while (i < offsets.length) {
-      res.push(API.board.getComments({
-        group_id: ${groupId},
-        topic_id: ${topicId},
-        count: 100,
-        offset: offsets[i],
-        extended: 1
-      }));
-      i = i + 1;
-    }
-    return res;
-  `;
-  const url = `https://api.vk.ru/method/execute?access_token=${token}&v=${API_VERSION}&code=${encodeURIComponent(code)}`;
-  const data = await executeRequest<any>(url);
-  if (data.error) {
-    throw new Error(`VK execute error: ${JSON.stringify(data.error)}`);
-  }
-  if (!data.response || !Array.isArray(data.response)) {
-    return [];
-  }
-  return data.response;
 };
 
 // Récupère les premiers commentaires de plusieurs topics en un seul appel execute
@@ -140,17 +105,28 @@ const fetchMultipleTopics = async (
   const code = `return [${calls}];`;
   const url = `https://api.vk.ru/method/execute?access_token=${token}&v=${API_VERSION}&code=${encodeURIComponent(code)}`;
 
-  const data = await executeRequest<any>(url);
-  if (data.error) {
-    throw new Error(`VK execute error: ${JSON.stringify(data.error)}`);
+  try {
+    const data = await executeRequest<any>(url);
+    if (data.error || (Array.isArray(data.execute_errors) && data.execute_errors.length > 0)) {
+      throw new Error(`VK execute error: ${JSON.stringify(data.error || data.execute_errors)}`);
+    }
+    if (!Array.isArray(data.response) || data.response.length !== topics.length) {
+      throw new Error("VK returned an incomplete multi-topic response");
+    }
+    if (data.response.some((response: any) => !response || !Array.isArray(response.items))) {
+      throw new Error("VK returned an invalid multi-topic response");
+    }
+    return data.response;
+  } catch (error) {
+    logWarn("VK execute unavailable; using direct board calls.", error);
+    return Promise.all(topics.map(async (topic) => {
+      const data = await fetchVkTopic(token, topic.groupId, topic.topicId);
+      if (data.error || !data.response || !Array.isArray(data.response.items)) {
+        throw new Error(`VK board error: ${JSON.stringify(data.error || data)}`);
+      }
+      return data.response;
+    }));
   }
-  if (!Array.isArray(data.response) || data.response.length !== topics.length) {
-    throw new Error("VK returned an incomplete multi-topic response");
-  }
-  if (data.response.some((response: any) => !response || !Array.isArray(response.items))) {
-    throw new Error("VK returned an invalid multi-topic response");
-  }
-  return data.response;
 };
 
 /**
@@ -698,32 +674,25 @@ const fetchAllComments = async (
   const allItems: any[] = [];
   let offset = 0;
   const count = 100;
-  const BATCH_SIZE = 10;
-  const MAX_BATCHES = 100;
-  let batchNumber = 0;
+  const MAX_PAGES = 1000;
 
-  while (batchNumber < MAX_BATCHES) {
-    batchNumber++;
-    const offsets: number[] = [];
-    for (let i = 0; i < BATCH_SIZE; i++) {
-      offsets.push(offset + i * count);
-    }
-
-    let responses: any[] = [];
+  for (let page = 0; page < MAX_PAGES; page++) {
+    let response: any = null;
     let retries = 0;
     let lastError: unknown = null;
 
     while (retries < maxRetries) {
       try {
-        responses = await fetchVkTopicBatch(token, groupId, topicId, offsets);
-        if (responses.length !== offsets.length || responses.some((r) => !r || !Array.isArray(r.items))) {
-          throw new Error(`VK returned an incomplete batch for topic ${topicId}`);
+        const data = await fetchVkTopic(token, groupId, topicId, offset);
+        if (data.error || !data.response || !Array.isArray(data.response.items)) {
+          throw new Error(`VK board error: ${JSON.stringify(data.error || data)}`);
         }
+        response = data.response;
         break;
       } catch (error) {
         lastError = error;
         logWarn(
-          `Network/execute error for topic ${topicId} (attempt ${retries + 1}/${maxRetries}):`,
+          `Network/API error for topic ${topicId} (attempt ${retries + 1}/${maxRetries}):`,
           error
         );
         retries++;
@@ -734,27 +703,16 @@ const fetchAllComments = async (
       }
     }
 
-    if (responses.length !== offsets.length || responses.some((r) => !r || !Array.isArray(r.items))) {
+    if (!response) {
       throw lastError instanceof Error
         ? lastError
         : new Error(`Unable to fetch comments for topic ${topicId}`);
     }
 
-    let reachedEnd = false;
-    for (let idx = 0; idx < responses.length; idx++) {
-      const resp = responses[idx];
-      const items = resp.items;
-      allItems.push(...items);
-      if (items.length < count) {
-        reachedEnd = true;
-        break;
-      }
-    }
-
-    offset += count * BATCH_SIZE;
-    if (reachedEnd) return allItems;
-
-    await sleep(200);
+    const items = response.items;
+    allItems.push(...items);
+    offset += items.length;
+    if (items.length < count || offset >= Number(response.count || 0)) return allItems;
   }
 
   throw new Error(`Safety limit reached while fetching topic ${topicId}`);


### PR DESCRIPTION
Part of #44 and mobile counterpart to #45.

- use Vkomic's registered Android VK ID application (client ID `54761286`)
- replace the legacy implicit Kate Mobile flow with OAuth 2.1 Authorization Code + PKCE
- return directly to `vk54761286://vk.ru` without copying a token
- store access and refresh credentials in Android Keystore/iOS Keychain through SecureStore
- refresh short-lived access tokens and discard legacy Kate sessions
- request only the required `docs` scope
- use direct `board.getComments` pagination and fall back when `execute` is unavailable
- identify API traffic as Vkomic

Validation:
- `npx tsc --noEmit`
- `npx expo config --type public --json`
- Android manifest merge (`:app:processDebugMainManifest`)
- private-key and legacy-auth scans

The PR remains draft until the new VK ID login is exercised on a physical Android device.