### PR TITLE
corrige les liens vk.ru et ameliore la reprise des telechargements

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -259,6 +259,7 @@ const App: React.FC = () => {
               resumeDownload={downloads.resumeDownload}
               cancelDownload={downloads.cancelDownload}
               retryDownload={downloads.retryDownload}
+              resetDownload={downloads.resetDownload}
               clearDownloads={downloads.clearDownloads}
             />
           </div>

--- a/components/DownloadsView.tsx
+++ b/components/DownloadsView.tsx
@@ -22,6 +22,7 @@ interface DownloadsViewProps {
   resumeDownload: (id: string) => void;
   cancelDownload: (id: string) => void;
   retryDownload: (id: string) => void;
+  resetDownload: (id: string) => void;
   syncedData: VkNode[] | null;
   downloadPath?: string;
   clearDownloads: () => void;
@@ -37,6 +38,7 @@ interface RowProps {
   resumeDownload: (id: string) => void;
   cancelDownload: (id: string) => void;
   retryDownload: (id: string) => void;
+  resetDownload: (id: string) => void;
   openFolder: (path?: string) => void;
 }
 
@@ -47,6 +49,7 @@ const DownloadRow = React.memo(({
   resumeDownload,
   cancelDownload,
   retryDownload,
+  resetDownload,
   openFolder
 }: RowProps) => {
   const isCompleted = d.status === "completed";
@@ -130,6 +133,9 @@ const DownloadRow = React.memo(({
                   <Pause size={16} />
                 </button>
               )}
+              <button onClick={() => resetDownload(d.id)} className="p-1.5 hover:bg-slate-700 rounded text-slate-300" title={t.tooltips.resetDownload}>
+                <RefreshCw size={16} />
+              </button>
               <button onClick={() => cancelDownload(d.id)} className="p-1.5 hover:bg-rose-900/30 rounded text-rose-400" title={t.tooltips.cancel}>
                 <X size={16} />
               </button>
@@ -152,6 +158,7 @@ const DownloadCard = React.memo(({
   resumeDownload,
   cancelDownload,
   retryDownload,
+  resetDownload,
   openFolder
 }: RowProps) => {
   const isCompleted = d.status === "completed";
@@ -221,6 +228,10 @@ const DownloadCard = React.memo(({
               {isPaused ? <Play size={14} /> : <Pause size={14} />}
               <span>{isPaused ? t.tooltips.resume : t.tooltips.pause}</span>
             </button>
+            <button onClick={() => resetDownload(d.id)} className="flex-1 min-w-[100px] px-3 py-2 rounded-lg bg-slate-800 text-slate-200 border border-slate-700/50 text-sm font-semibold flex items-center justify-center gap-2" title={t.tooltips.resetDownload}>
+              <RefreshCw size={14} />
+              <span>{t.tooltips.resetDownload}</span>
+            </button>
             <button onClick={() => cancelDownload(d.id)} className="flex-1 min-w-[100px] px-3 py-2 rounded-lg bg-rose-900/40 text-rose-300 border border-rose-900/60 text-sm font-semibold flex items-center justify-center gap-2">
               <X size={14} />
               <span>{t.tooltips.cancel}</span>
@@ -243,6 +254,7 @@ const DownloadsView: React.FC<DownloadsViewProps> = ({
   resumeDownload,
   cancelDownload,
   retryDownload,
+  resetDownload,
   syncedData,
   downloadPath,
   clearDownloads,
@@ -451,6 +463,7 @@ const DownloadsView: React.FC<DownloadsViewProps> = ({
                           resumeDownload={resumeDownload}
                           cancelDownload={cancelDownload}
                           retryDownload={retryDownload}
+                          resetDownload={resetDownload}
                           openFolder={openFolder}
                         />
                       ))}
@@ -469,6 +482,7 @@ const DownloadsView: React.FC<DownloadsViewProps> = ({
                       resumeDownload={resumeDownload}
                       cancelDownload={cancelDownload}
                       retryDownload={retryDownload}
+                      resetDownload={resetDownload}
                       openFolder={openFolder}
                     />
                   ))}

--- a/components/MainView.tsx
+++ b/components/MainView.tsx
@@ -32,6 +32,7 @@ interface MainViewProps {
   resumeDownload: (id: string) => void;
   cancelDownload: (id: string) => void;
   retryDownload: (id: string) => void;
+  resetDownload: (id: string) => void;
   clearDownloads: () => void;
 }
 
@@ -63,6 +64,7 @@ const MainView: React.FC<MainViewProps> = ({
   resumeDownload,
   cancelDownload,
   retryDownload,
+  resetDownload,
   clearDownloads,
 }) => {
   const [navPath, setNavPath] = useState<VkNode[]>([]);
@@ -110,6 +112,7 @@ const MainView: React.FC<MainViewProps> = ({
                   resumeDownload={resumeDownload}
                   cancelDownload={cancelDownload}
                   retryDownload={retryDownload}
+                  resetDownload={resetDownload}
                   downloadPath={downloadPath}
                   clearDownloads={clearDownloads}
                   syncedData={syncedData}

--- a/hooks/useDownloads.ts
+++ b/hooks/useDownloads.ts
@@ -6,6 +6,30 @@ import { formatBytes, formatSpeed } from "../utils/formatters";
 import { idbDel, idbGet, idbGetByPrefix, idbSet, migrateLocalStorageJsonToIdb } from "../utils/storage";
 import { tauriFs, tauriEvents } from "../lib/tauri";
 
+const getDownloadTarget = (download: DownloadItem, downloadPath: string) => {
+    if (!downloadPath || downloadPath === DEFAULT_DOWNLOAD_PATH) return null;
+
+    let fileName = download.title;
+    if (download.extension) {
+        const ext = download.extension.toLowerCase();
+        if (!fileName.toLowerCase().endsWith(`.${ext}`)) {
+            fileName = `${fileName}.${ext}`;
+        }
+    }
+
+    let directory = downloadPath;
+    if (download.subFolder) {
+        const safeSubFolder = download.subFolder.replace(/[<>:"/\\|?*]+/g, "").trim();
+        if (safeSubFolder.length > 0) {
+            const separator = downloadPath.includes("\\") ? "\\" : "/";
+            const cleanPath = downloadPath.endsWith(separator) ? downloadPath.slice(0, -1) : downloadPath;
+            directory = `${cleanPath}${separator}${safeSubFolder}`;
+        }
+    }
+
+    return { directory, fileName };
+};
+
 export const useDownloads = (downloadPath: string, vkToken?: string) => {
     const [downloads, setDownloads] = useState<DownloadItem[]>([]);
     const [downloadsHydrated, setDownloadsHydrated] = useState(false);
@@ -114,6 +138,7 @@ export const useDownloads = (downloadPath: string, vkToken?: string) => {
                 status: "pending", extension: node.extension, speed: "0 MB/s",
                 createdAt: new Date().toISOString(),
                 size: existing && existing.size ? existing.size : formattedSize,
+                totalBytes: node.sizeBytes ?? existing?.totalBytes,
                 path: existing && (existing as any).path ? (existing as any).path : undefined,
                 vkOwnerId: node.vkOwnerId,
                 vkDocId: node.id.replace("doc_", ""),
@@ -152,27 +177,19 @@ export const useDownloads = (downloadPath: string, vkToken?: string) => {
 
             enqueued.add(d.id);
 
-            let fileName = d.title;
-            if (d.extension) {
-                const ext = d.extension.toLowerCase();
-                if (!fileName.toLowerCase().endsWith(`.${ext}`)) {
-                    fileName = `${fileName}.${ext}`;
-                }
-            }
-
-            let targetPath = downloadPath;
-            if (d.subFolder) {
-                const safeSubFolder = d.subFolder.replace(/[<>:"/\\|?*]+/g, "").trim();
-                if (safeSubFolder.length > 0) {
-                    const separator = downloadPath.includes("\\") ? "\\" : "/";
-                    const cleanPath = downloadPath.endsWith(separator) ? downloadPath.slice(0, -1) : downloadPath;
-                    targetPath = `${cleanPath}${separator}${safeSubFolder}`;
-                }
-            }
+            const target = getDownloadTarget(d, downloadPath);
+            if (!target) continue;
 
             const enqueue = async () => {
                 try {
-                    await tauriFs.queueDownload(d.id, d.url!, targetPath, fileName, vkToken);
+                    await tauriFs.queueDownload(
+                        d.id,
+                        d.url!,
+                        target.directory,
+                        target.fileName,
+                        d.totalBytes,
+                        vkToken,
+                    );
                 } catch {
                     enqueued.delete(d.id);
                     setDownloads((prev) =>
@@ -324,6 +341,29 @@ export const useDownloads = (downloadPath: string, vkToken?: string) => {
         );
     }, []);
 
+    const resetDownload = useCallback((id: string) => {
+        const download = downloadsRef.current.find((d) => d.id === id);
+        const target = download && getDownloadTarget(download, downloadPath);
+        if (!download || !target) return;
+
+        enqueuedPendingDownloadsRef.current.delete(id);
+        void tauriFs.resetDownload(id, target.directory, target.fileName)
+            .then(() => {
+                setDownloads((prev) =>
+                    prev.map((d) =>
+                        d.id === id
+                            ? { ...d, status: "pending", progress: 0, speed: "0 MB/s", createdAt: new Date().toISOString() }
+                            : d
+                    )
+                );
+            })
+            .catch(() => {
+                setDownloads((prev) =>
+                    prev.map((d) => d.id === id ? { ...d, status: "error", speed: "Erreur de réinitialisation" } : d)
+                );
+            });
+    }, [downloadPath]);
+
     const clearDownloads = useCallback(() => {
         tauriFs.clearDownloadQueue().catch(console.error);
         enqueuedPendingDownloadsRef.current.clear();
@@ -337,6 +377,7 @@ export const useDownloads = (downloadPath: string, vkToken?: string) => {
         resumeDownload,
         cancelDownload,
         retryDownload,
+        resetDownload,
         clearDownloads,
     };
 };

--- a/i18n/en.ts
+++ b/i18n/en.ts
@@ -132,6 +132,7 @@ export const en: Translations = {
     resume: "Resume",
     pause: "Pause",
     cancel: "Cancel",
+    resetDownload: "Reset download",
     openFolder: "Open folder",
   },
 

--- a/i18n/fr.ts
+++ b/i18n/fr.ts
@@ -132,6 +132,7 @@ export const fr = {
     resume: "Reprendre",
     pause: "Pause",
     cancel: "Annuler",
+    resetDownload: "Réinitialiser le téléchargement",
     openFolder: "Ouvrir le dossier",
   },
 

--- a/lib/tauri.ts
+++ b/lib/tauri.ts
@@ -23,9 +23,11 @@ export const tauriFs = {
     listDirectory: (path: string) => invoke<any>("fs_list_directory", { path }),
     openPath: (path: string) => invoke<void>("fs_open_path", { path }),
     revealPath: (path: string) => invoke<void>("fs_reveal_path", { path }),
-    queueDownload: (id: string, url: string, directory: string, fileName: string, token?: string) =>
-        invoke<void>("fs_queue_download", { id, url, directory, fileName, token }),
+    queueDownload: (id: string, url: string, directory: string, fileName: string, expectedSize?: number, token?: string) =>
+        invoke<void>("fs_queue_download", { id, url, directory, fileName, expectedSize, token }),
     cancelDownload: (id: string) => invoke<boolean>("fs_cancel_download", { id }),
+    resetDownload: (id: string, directory: string, fileName: string) =>
+        invoke<void>("fs_reset_download", { id, directory, fileName }),
     clearDownloadQueue: () => invoke<number>("fs_clear_download_queue"),
 };
 

--- a/src-tauri/src/download.rs
+++ b/src-tauri/src/download.rs
@@ -1,5 +1,7 @@
 use anyhow::Result;
 use futures_util::StreamExt;
+use reqwest::header::{ACCEPT_ENCODING, CONTENT_RANGE, RANGE};
+use reqwest::StatusCode;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
@@ -8,7 +10,11 @@ use tokio::io::AsyncWriteExt;
 use tokio::sync::Mutex;
 
 const MAX_ACTIVE_DOWNLOADS: usize = 2;
-const VKOMIC_USER_AGENT: &str = "KateMobileAndroid/110.1 lite-x86_64 (Android 11; SDK 30; x86_64; en)";
+const MAX_DOWNLOAD_ATTEMPTS: usize = 5;
+const FALLBACK_AFTER_FAILURES: usize = 2;
+const FALLBACK_CHUNK_SIZE: u64 = 32 * 1024 * 1024;
+const VKOMIC_USER_AGENT: &str =
+    "KateMobileAndroid/110.1 lite-x86_64 (Android 11; SDK 30; x86_64; en)";
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct DownloadTask {
@@ -16,6 +22,7 @@ pub struct DownloadTask {
     pub url: String,
     pub directory: String,
     pub file_name: String,
+    pub expected_size: Option<u64>,
     pub token: Option<String>,
 }
 
@@ -34,6 +41,11 @@ pub struct DownloadManager {
     queue: Arc<Mutex<VecDeque<DownloadTask>>>,
     active: Arc<Mutex<HashMap<String, tokio::task::JoinHandle<()>>>>,
     cancel_tokens: Arc<Mutex<HashMap<String, tokio::sync::watch::Sender<bool>>>>,
+}
+
+enum DownloadAttemptOutcome {
+    Complete,
+    MoreData,
 }
 
 impl DownloadManager {
@@ -83,6 +95,31 @@ impl DownloadManager {
         }
 
         false
+    }
+
+    pub async fn reset_task(&self, app: AppHandle, task_id: String) -> bool {
+        let mut queue = self.queue.lock().await;
+        let queued_before = queue.len();
+        queue.retain(|task| task.id != task_id);
+        let was_queued = queue.len() != queued_before;
+        drop(queue);
+
+        let mut cancel_tokens = self.cancel_tokens.lock().await;
+        let mut active = self.active.lock().await;
+        let was_active = if let Some(sender) = cancel_tokens.remove(&task_id) {
+            let _ = sender.send(true);
+            if let Some(handle) = active.remove(&task_id) {
+                handle.abort();
+            }
+            true
+        } else {
+            false
+        };
+        drop(active);
+        drop(cancel_tokens);
+
+        self.schedule_next(app).await;
+        was_queued || was_active
     }
 
     pub async fn clear_queue(&self, app: AppHandle) -> usize {
@@ -215,10 +252,59 @@ async fn download_file_worker(
     task: DownloadTask,
     cancel_rx: tokio::sync::watch::Receiver<bool>,
 ) -> Result<()> {
-    println!("DEBUG: Worker processing URL: {}", task.url);
     let client = reqwest::Client::builder()
         .user_agent(VKOMIC_USER_AGENT)
         .build()?;
+    let mut failed_attempts = 0usize;
+    loop {
+        let chunk_size =
+            (failed_attempts >= FALLBACK_AFTER_FAILURES).then_some(FALLBACK_CHUNK_SIZE);
+        match download_file_attempt(
+            app.clone(),
+            task.clone(),
+            cancel_rx.clone(),
+            &client,
+            chunk_size,
+        )
+        .await
+        {
+            Ok(DownloadAttemptOutcome::Complete) => return Ok(()),
+            Ok(DownloadAttemptOutcome::MoreData) => continue,
+            Err(error) if *cancel_rx.borrow() => return Err(error),
+            Err(error) => {
+                failed_attempts += 1;
+                if failed_attempts == MAX_DOWNLOAD_ATTEMPTS {
+                    return Err(error);
+                }
+                // VK sometimes closes a ranged response before its declared end.
+                // The partial bytes are safely retained; retrying with a new Range
+                // request resumes from the current file size.
+                println!(
+                    "DEBUG: Download attempt {}/{} failed for {}: {:#}. Retrying{}...",
+                    failed_attempts,
+                    MAX_DOWNLOAD_ATTEMPTS,
+                    task.id,
+                    error,
+                    if failed_attempts == FALLBACK_AFTER_FAILURES {
+                        " with 32 MiB chunks"
+                    } else {
+                        ""
+                    }
+                );
+                tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+            }
+        }
+    }
+}
+
+async fn download_file_attempt(
+    app: AppHandle,
+    task: DownloadTask,
+    cancel_rx: tokio::sync::watch::Receiver<bool>,
+    client: &reqwest::Client,
+    chunk_size: Option<u64>,
+) -> Result<DownloadAttemptOutcome> {
+    println!("DEBUG: Worker processing task {}", task.id);
 
     // Sanitization du nom de fichier pour Windows (remplace les caractères interdits par _)
     let safe_file_name: String = task
@@ -243,18 +329,72 @@ async fn download_file_worker(
         start_byte = std::fs::metadata(&path)?.len();
     }
 
-    let mut request = client.get(&task.url);
-    if start_byte > 0 {
-        request = request.header("Range", format!("bytes={}-", start_byte));
-    }
+    // Keep the UI in sync with the worker even if VK resets the stream before
+    // the first chunk reaches the throttled progress reporter.
+    let _ = app.emit(
+        "download-progress",
+        ProgressPayload {
+            id: task.id.clone(),
+            progress: task
+                .expected_size
+                .map(|total| (start_byte as f64 / total as f64) * 100.0)
+                .unwrap_or(0.0),
+            received_bytes: start_byte,
+            total_bytes: task.expected_size,
+            speed_bytes: 0.0,
+        },
+    );
 
+    // Normal downloads keep the original single response. After two failed
+    // attempts, request bounded ranges with identity encoding so one unstable
+    // CDN response cannot discard the already-written prefix.
+    let mut request = client.get(&task.url);
+    if let Some(chunk_size) = chunk_size {
+        let range_end = start_byte.saturating_add(chunk_size - 1);
+        println!(
+            "DEBUG: Fallback request bytes {}-{} for {}",
+            start_byte, range_end, task.id
+        );
+        request = request
+            .header(ACCEPT_ENCODING, "identity")
+            .header(RANGE, format!("bytes={start_byte}-{range_end}"));
+    } else if start_byte > 0 {
+        request = request.header(RANGE, format!("bytes={start_byte}-"));
+    }
     let response = request.send().await?;
 
     if *cancel_rx.borrow() {
         return Err(anyhow::anyhow!("Download cancelled"));
     }
 
-    let total_size = response.content_length().map(|l| l + start_byte);
+    let content_range_total = response
+        .headers()
+        .get(CONTENT_RANGE)
+        .and_then(|value| value.to_str().ok())
+        .and_then(parse_content_range_total);
+
+    if response.status() == StatusCode::RANGE_NOT_SATISFIABLE
+        && content_range_total.is_some_and(|total| start_byte >= total)
+    {
+        app.emit(
+            "download-result",
+            serde_json::json!({
+                "id": task.id,
+                "ok": true,
+                "path": path.to_string_lossy()
+            }),
+        )?;
+        return Ok(DownloadAttemptOutcome::Complete);
+    }
+
+    if !response.status().is_success() {
+        return Err(anyhow::anyhow!(
+            "VK returned HTTP {} for the requested byte range",
+            response.status()
+        ));
+    }
+
+    let response_content_length = response.content_length();
 
     // Détermine le mode d'ouverture selon le code HTTP
     let mut file = if response.status() == 206 {
@@ -281,6 +421,10 @@ async fn download_file_worker(
             .await?
     };
 
+    let total_size = content_range_total
+        .or(task.expected_size)
+        .or_else(|| response_content_length.map(|l| l + start_byte));
+
     // Plus besoin de seek/set_len manuel car géré par les flags OpenOptions
 
     let mut stream = response.bytes_stream();
@@ -301,7 +445,22 @@ async fn download_file_worker(
             return Err(anyhow::anyhow!("Download cancelled"));
         }
 
-        let chunk = item?;
+        let chunk = match item {
+            Ok(chunk) => chunk,
+            Err(error) => {
+                println!(
+                    "DEBUG: Stream interrupted after {} new bytes (resume offset {}).",
+                    downloaded, start_byte
+                );
+                // Only fallback chunks resume immediately after a partial
+                // response. A normal stream failure counts toward the two
+                // failures required before enabling bounded ranges.
+                if chunk_size.is_some() && downloaded > 0 {
+                    return Ok(DownloadAttemptOutcome::MoreData);
+                }
+                return Err(error.into());
+            }
+        };
         file.write_all(&chunk).await?;
         downloaded += chunk.len() as u64;
 
@@ -333,6 +492,29 @@ async fn download_file_worker(
         }
     }
 
+    let total_downloaded = start_byte + downloaded;
+    let progress = total_size
+        .map(|total| (total_downloaded as f64 / total as f64) * 100.0)
+        .unwrap_or(0.0);
+    app.emit(
+        "download-progress",
+        ProgressPayload {
+            id: task.id.clone(),
+            progress,
+            received_bytes: total_downloaded,
+            total_bytes: total_size,
+            speed_bytes: if start_time.elapsed().is_zero() {
+                0.0
+            } else {
+                downloaded as f64 / start_time.elapsed().as_secs_f64()
+            },
+        },
+    )?;
+
+    if chunk_size.is_some() && total_size.is_some_and(|total| total_downloaded < total) {
+        return Ok(DownloadAttemptOutcome::MoreData);
+    }
+
     app.emit(
         "download-result",
         serde_json::json!({
@@ -342,5 +524,36 @@ async fn download_file_worker(
         }),
     )?;
 
+    Ok(DownloadAttemptOutcome::Complete)
+}
+
+fn parse_content_range_total(value: &str) -> Option<u64> {
+    value.rsplit('/').next()?.parse().ok()
+}
+
+pub async fn reset_partial_download(directory: &str, file_name: &str) -> Result<()> {
+    let safe_file_name: String = file_name
+        .chars()
+        .map(|c| if "<>:\"/\\\\|?*".contains(c) { '_' } else { c })
+        .collect();
+    let path = std::path::Path::new(directory).join(&safe_file_name);
+    if path.exists() {
+        preserve_partial(&path, &safe_file_name, "reset").await?;
+    }
+    Ok(())
+}
+
+async fn preserve_partial(path: &std::path::Path, file_name: &str, reason: &str) -> Result<()> {
+    let suffix = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    let backup_path = path.with_file_name(format!("{file_name}.{reason}-backup-{suffix}"));
+
+    tokio::fs::rename(path, &backup_path).await?;
+    println!(
+        "DEBUG: Preserved partial download at {:?} ({reason} backup)",
+        backup_path,
+    );
     Ok(())
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,10 +1,10 @@
 mod download;
 mod fs_ops;
+mod settings;
 mod vk_api;
 mod vk_parser;
-mod settings;
 
-use crate::download::{DownloadManager, DownloadTask};
+use crate::download::{reset_partial_download, DownloadManager, DownloadTask};
 use crate::fs_ops::{list_directory, open_path, reveal_path, DirList};
 use crate::vk_api::VkApi;
 use crate::vk_parser::VkNode;
@@ -91,6 +91,7 @@ async fn fs_queue_download(
     url: String,
     directory: String,
     file_name: String,
+    expected_size: Option<u64>,
     token: Option<String>,
 ) -> Result<(), String> {
     let task = DownloadTask {
@@ -98,6 +99,7 @@ async fn fs_queue_download(
         url,
         directory,
         file_name,
+        expected_size,
         token,
     };
     state.download_manager.add_task(app, task).await;
@@ -112,6 +114,22 @@ async fn fs_cancel_download(
 ) -> Result<bool, String> {
     let cancelled = state.download_manager.cancel_task(app, id).await;
     Ok(cancelled)
+}
+
+#[tauri::command]
+async fn fs_reset_download(
+    app: AppHandle,
+    state: State<'_, AppState>,
+    id: String,
+    directory: String,
+    file_name: String,
+) -> Result<(), String> {
+    // Stop a pending/active task first, then preserve its partial file under a
+    // unique backup name. The frontend can enqueue the same document afresh.
+    state.download_manager.reset_task(app, id).await;
+    reset_partial_download(&directory, &file_name)
+        .await
+        .map_err(|e| e.to_string())
 }
 
 #[tauri::command]
@@ -160,6 +178,7 @@ pub fn run() {
             fs_reveal_path,
             fs_queue_download,
             fs_cancel_download,
+            fs_reset_download,
             fs_clear_download_queue,
             settings_load,
             settings_save

--- a/src-tauri/src/vk_parser.rs
+++ b/src-tauri/src/vk_parser.rs
@@ -35,14 +35,15 @@ lazy_static! {
 
     static ref RE_BBCODE: Regex = Regex::new(r"\[topic-(\d+)_(\d+)\|([^\]]+)\]").unwrap();
     static ref RE_MENTION: Regex = Regex::new(r"@topic-(\d+)_(\d+)(?:\?post=(\d+))?(?:\s*\(([^)]+)\))?").unwrap();
-    // Support m.vk.com, w.vk.com, new.vk.com, etc. - Also capture post_id for mentions
-    static ref RE_URL: Regex = Regex::new(r"https?://(?:[a-z0-9]+\.)?vk\.com/topic-(\d+)_(\d+)(?:\?post=(\d+))?").unwrap();
+    // Support VK's .com and .ru domains plus mobile subdomains. VK now exposes
+    // the default Vkomic board through vk.ru, while older indexes use vk.com.
+    static ref RE_URL: Regex = Regex::new(r"https?://(?:[a-z0-9]+\.)?vk\.(?:com|ru)/topic-(\d+)_(\d+)(?:\?post=(\d+))?").unwrap();
     // Newer VK board links can point to topics through /boardGROUP?...topic...
-    static ref RE_BOARD_URL: Regex = Regex::new(r"https?://(?:[a-z0-9]+\.)?vk\.com/board(\d+)\?[^\s\]]*(?:topic-|topic_id=|tid=)(?:-?\d+_)?(\d+)").unwrap();
-    // Inverted format: https://vk.com/topic-XXX|Titre] - BBCode malformed
-    static ref RE_URL_INVERTED: Regex = Regex::new(r"https?://(?:[a-z0-9]+\.)?vk\.com/topic-(\d+)_(\d+)\|([^\]]+)\]").unwrap();
-    // Support documents in text: https://vk.com/doc-123_456
-    static ref RE_DOC_URL: Regex = Regex::new(r"https?://(?:[a-z0-9]+\.)?vk\.com/doc(-?\d+)_(\d+)").unwrap();
+    static ref RE_BOARD_URL: Regex = Regex::new(r"https?://(?:[a-z0-9]+\.)?vk\.(?:com|ru)/board(\d+)\?[^\s\]]*(?:topic-|topic_id=|tid=)(?:-?\d+_)?(\d+)").unwrap();
+    // Inverted format: https://vk.ru/topic-XXX|Titre] - BBCode malformed
+    static ref RE_URL_INVERTED: Regex = Regex::new(r"https?://(?:[a-z0-9]+\.)?vk\.(?:com|ru)/topic-(\d+)_(\d+)\|([^\]]+)\]").unwrap();
+    // Support documents in text: https://vk.ru/doc-123_456
+    static ref RE_DOC_URL: Regex = Regex::new(r"https?://(?:[a-z0-9]+\.)?vk\.(?:com|ru)/doc(-?\d+)_(\d+)").unwrap();
 }
 
 pub fn clean_title(text: &str) -> String {
@@ -98,7 +99,7 @@ pub fn parse_topic_body(text: &str, exclude_topic_id: Option<&str>) -> Vec<VkNod
                     id: unique_id,
                     title,
                     node_type: "genre".to_string(),
-                    url: Some(format!("https://vk.com/topic-{}_{}", group_id, topic_id)),
+                    url: Some(format!("https://vk.ru/topic-{}_{}", group_id, topic_id)),
                     vk_group_id: Some(group_id.to_string()),
                     vk_topic_id: Some(topic_id.to_string()),
                     children: Some(Vec::new()),
@@ -149,7 +150,7 @@ pub fn parse_topic_body(text: &str, exclude_topic_id: Option<&str>) -> Vec<VkNod
                     id: unique_id,
                     title,
                     node_type: "genre".to_string(),
-                    url: Some(format!("https://vk.com/topic-{}_{}", group_id, topic_id)),
+                    url: Some(format!("https://vk.ru/topic-{}_{}", group_id, topic_id)),
                     vk_group_id: Some(group_id.to_string()),
                     vk_topic_id: Some(topic_id.to_string()),
                     children: Some(Vec::new()),
@@ -201,7 +202,7 @@ pub fn parse_topic_body(text: &str, exclude_topic_id: Option<&str>) -> Vec<VkNod
                         id: unique_id,
                         title,
                         node_type: "genre".to_string(),
-                        url: Some(format!("https://vk.com/topic-{}_{}", group_id, topic_id)),
+                        url: Some(format!("https://vk.ru/topic-{}_{}", group_id, topic_id)),
                         vk_group_id: Some(group_id.to_string()),
                         vk_topic_id: Some(topic_id.to_string()),
                         children: Some(Vec::new()),
@@ -273,7 +274,10 @@ pub fn parse_topic_body(text: &str, exclude_topic_id: Option<&str>) -> Vec<VkNod
             // Try previous line if no title found
             if (title.is_empty() || title.len() < 2) && i > 0 {
                 let prev_line = lines[i - 1].trim();
-                if !prev_line.contains("vk.com") && prev_line.len() > 2 {
+                if !prev_line.contains("vk.com")
+                    && !prev_line.contains("vk.ru")
+                    && prev_line.len() > 2
+                {
                     title = clean_title(prev_line);
                 }
             }
@@ -281,7 +285,10 @@ pub fn parse_topic_body(text: &str, exclude_topic_id: Option<&str>) -> Vec<VkNod
             // Try text after URL as fallback (mobile behavior)
             if (title.is_empty() || title.len() < 2) && url_end < line.len() {
                 let after_text = &line[url_end..].trim();
-                if !after_text.is_empty() && after_text.len() > 2 && !after_text.contains("vk.com")
+                if !after_text.is_empty()
+                    && after_text.len() > 2
+                    && !after_text.contains("vk.com")
+                    && !after_text.contains("vk.ru")
                 {
                     title = clean_title(after_text);
                 }
@@ -302,7 +309,7 @@ pub fn parse_topic_body(text: &str, exclude_topic_id: Option<&str>) -> Vec<VkNod
                         id: unique_id,
                         title,
                         node_type: "genre".to_string(),
-                        url: Some(format!("https://vk.com/topic-{}_{}", group_id, topic_id)),
+                        url: Some(format!("https://vk.ru/topic-{}_{}", group_id, topic_id)),
                         vk_group_id: Some(group_id.to_string()),
                         vk_topic_id: Some(topic_id.to_string()),
                         children: Some(Vec::new()),
@@ -346,7 +353,10 @@ pub fn parse_topic_body(text: &str, exclude_topic_id: Option<&str>) -> Vec<VkNod
             // Previous line if needed
             if (title.is_empty() || title.len() < 2) && i > 0 {
                 let prev_line = lines[i - 1].trim();
-                if !prev_line.contains("vk.com") && prev_line.len() > 2 {
+                if !prev_line.contains("vk.com")
+                    && !prev_line.contains("vk.ru")
+                    && prev_line.len() > 2
+                {
                     title = clean_title(prev_line);
                 }
             }
@@ -357,7 +367,10 @@ pub fn parse_topic_body(text: &str, exclude_topic_id: Option<&str>) -> Vec<VkNod
             {
                 if i > 0 {
                     let prev_line = lines[i - 1].trim();
-                    if !prev_line.contains("vk.com") && prev_line.len() > 2 {
+                    if !prev_line.contains("vk.com")
+                        && !prev_line.contains("vk.ru")
+                        && prev_line.len() > 2
+                    {
                         title = clean_title(prev_line);
                     }
                 }
@@ -372,7 +385,7 @@ pub fn parse_topic_body(text: &str, exclude_topic_id: Option<&str>) -> Vec<VkNod
                 id: unique_id,
                 title,
                 node_type: "file".to_string(),
-                url: Some(format!("https://vk.com/doc{}_{}", owner_id, doc_id)),
+                url: Some(format!("https://vk.ru/doc{}_{}", owner_id, doc_id)),
                 extension: Some("FILE".to_string()),
                 vk_owner_id: Some(owner_id.to_string()),
                 vk_doc_id: Some(doc_id.to_string()),
@@ -446,4 +459,24 @@ pub fn extract_documents(items: &[serde_json::Value]) -> Vec<VkNode> {
     }
 
     nodes
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_topic_body;
+
+    #[test]
+    fn parses_vk_ru_topic_links_from_the_default_index() {
+        let text = "BDs en français / French comics books\nhttps://vk.ru/topic-203785966_47386771\n\nMangas en français / Mangas in french\nhttps://vk.ru/topic-203785966_47423270\n\nComics en français / Comics in french\nhttps://vk.ru/topic-203785966_47543940";
+
+        let nodes = parse_topic_body(text, None);
+
+        assert_eq!(nodes.len(), 3);
+        assert_eq!(nodes[0].title, "BDs en français / French comics books");
+        assert_eq!(nodes[0].vk_topic_id.as_deref(), Some("47386771"));
+        assert_eq!(
+            nodes[0].url.as_deref(),
+            Some("https://vk.ru/topic-203785966_47386771")
+        );
+    }
 }

--- a/types.ts
+++ b/types.ts
@@ -59,6 +59,7 @@ export interface DownloadItem {
   | "error";
   createdAt?: string; // ISO date de la dernre tentative
   size?: string;
+  totalBytes?: number;
   speed?: string;
   url?: string;
   vkOwnerId?: string;


### PR DESCRIPTION
j'ai rencontré quelques liens vk.ru qui n'etaient pas reconnus alors que les liens vk.com fonctionnaient, donc j'ai ajouté leur prise en charge pour les topics, boards et documents.

j'ai aussi ajouté un bouton pour reinitialiser un telechargement bloque sans devoir supprimer son entree de la liste. Le telechargement garde son fonctionnement habituel en un seul flux avec HTTP/2 quand VK le propose ; seulement apres deux echecs, il essaye une reprise par blocs de 32 Mo. Cela ne ralentit donc pas les fichiers qui se telechargent normalement, tout en donnant une solution de secours quand le CDN coupe plusieurs fois la connexion.

la taille connue du document est egalement utilisee pour afficher une progression plus fiable quand VK ne la renvoie pas directement.